### PR TITLE
Task #30: v0.2.0 GitHub Release/tag 생성 기록

### DIFF
--- a/mydocs/orders/20260509.md
+++ b/mydocs/orders/20260509.md
@@ -8,3 +8,4 @@
 | #24 | v0.2.0 GitHub Release/tag 준비 | 완료 | 완료: 01:35, 최종 보고서 + PR 게시 준비 |
 | #26 | v0.2.0 manifest release 상태와 checksum 확정 | 완료 | 완료: 02:31, 최종 보고서 + PR 게시 준비 |
 | #22 | README 상단 빠른 적용 안내 추가 | 완료 | 완료: 03:14, 최종 보고서 + PR 게시 준비 |
+| #30 | v0.2.0 GitHub Release/tag 생성 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260509.md
+++ b/mydocs/orders/20260509.md
@@ -8,4 +8,4 @@
 | #24 | v0.2.0 GitHub Release/tag 준비 | 완료 | 완료: 01:35, 최종 보고서 + PR 게시 준비 |
 | #26 | v0.2.0 manifest release 상태와 checksum 확정 | 완료 | 완료: 02:31, 최종 보고서 + PR 게시 준비 |
 | #22 | README 상단 빠른 적용 안내 추가 | 완료 | 완료: 03:14, 최종 보고서 + PR 게시 준비 |
-| #30 | v0.2.0 GitHub Release/tag 생성 | 진행중 | 구현계획서 작성 후 승인 대기 |
+| #30 | v0.2.0 GitHub Release/tag 생성 | 완료 | 완료: 05:47, 최종 보고서 + PR 게시 준비 |

--- a/mydocs/orders/20260509.md
+++ b/mydocs/orders/20260509.md
@@ -8,4 +8,4 @@
 | #24 | v0.2.0 GitHub Release/tag 준비 | 완료 | 완료: 01:35, 최종 보고서 + PR 게시 준비 |
 | #26 | v0.2.0 manifest release 상태와 checksum 확정 | 완료 | 완료: 02:31, 최종 보고서 + PR 게시 준비 |
 | #22 | README 상단 빠른 적용 안내 추가 | 완료 | 완료: 03:14, 최종 보고서 + PR 게시 준비 |
-| #30 | v0.2.0 GitHub Release/tag 생성 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #30 | v0.2.0 GitHub Release/tag 생성 | 진행중 | 구현계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m020_30.md
+++ b/mydocs/plans/task_m020_30.md
@@ -1,0 +1,139 @@
+# task_m020_30.md - v0.2.0 GitHub Release/tag 생성 수행계획서
+
+GitHub Issue: [#30](https://github.com/postmelee/hyper-waterfall/issues/30)
+마일스톤: M020
+
+## 목적
+
+`v0.2.0` Git tag와 GitHub Release를 생성해 M020 배포·업데이트 프로토콜 MVP의 canonical 배포 단위를 확정한다.
+
+이 task는 이미 `main`에 반영된 release 대상 commit을 고정하는 운영 작업이다. release tag는 작업 문서가 추가되는 `local/task30` 커밋이 아니라, release 전 검증을 통과한 최신 `origin/main` commit을 대상으로 생성한다.
+
+## 배경
+
+#24에서 `v0.2.0` GitHub Release/tag 준비 문서를 만들었고, #26에서 manifest checksum 상태를 file `ready`, root/directory `pending-release`, symlink `not-applicable` 기준으로 확정했다. #21에서는 npm publish 전 검증과 publish 승인 게이트를 정리했고, #22에서는 README 상단 빠른 적용 안내를 보강했다.
+
+현재 `v0.2.0` Git tag와 GitHub Release는 아직 존재하지 않는다. M020의 열린 이슈가 #30 외에는 없으므로, release 생성 전 최종 검증과 명시 승인 절차를 거쳐 `v0.2.0`을 publish한다.
+
+## 범위
+
+### 포함
+
+- release 생성 전 최종 검증 실행.
+- 최신 `origin/main` commit 확인과 release 대상 SHA 기록.
+- `v0.2.0` Git tag 생성.
+- `v0.2.0` tag 원격 push.
+- `docs/releases/v0.2.0.md`의 release notes 초안을 기준으로 GitHub Release 생성.
+- Git tag, GitHub Release, release notes, manifest/version 정합성 검증.
+- 단계 보고서, 최종 보고서, 오늘할일 갱신, PR 게시.
+
+### 제외
+
+- npm publish 실행.
+- Homebrew formula/tap 구현 또는 배포.
+- Docker image 구현 또는 배포.
+- Codex plugin, Claude plugin packaging 또는 배포.
+- 자동 release pipeline 구현.
+- root/directory checksum 공식 산식 확정.
+- `templates/manifest.json`의 `release.status` 변경. 별도 승인 없이는 현재 `planned` 기준을 유지한다.
+
+## 설계 방향
+
+- release tag 대상은 Stage 2 실행 시점에 최신화한 `origin/main` commit으로 고정한다.
+- `local/task30` 브랜치의 수행계획서, 단계 보고서, 최종 보고서 커밋은 release 대상에 포함하지 않는다.
+- GitHub Release 본문은 `docs/releases/v0.2.0.md`의 release notes 초안을 `/private/tmp`의 임시 notes 파일로 추출해 사용한다.
+- `npm publish`는 release와 분리한다. 이번 task에서 npm registry 상태 확인은 필요할 때만 참고로 수행하고 publish는 실행하지 않는다.
+- 실제 `git tag`, `git push origin v0.2.0`, `gh release create`는 구현계획서 승인 후, 해당 Stage 승인 시점에만 실행한다.
+- tag/release가 이미 존재하면 새로 만들지 않고 즉시 중단해 상태를 보고한다.
+
+## 예상 변경 파일
+
+신규:
+
+- `mydocs/plans/task_m020_30.md`
+- `mydocs/plans/task_m020_30_impl.md`
+- `mydocs/working/task_m020_30_stage1.md`
+- `mydocs/working/task_m020_30_stage2.md`
+- `mydocs/working/task_m020_30_stage3.md`
+- `mydocs/report/task_m020_30_report.md`
+
+수정:
+
+- `mydocs/orders/20260509.md`
+
+이번 task 산출물:
+
+- Git tag `v0.2.0`
+- GitHub Release `v0.2.0`
+- `mydocs/orders/20260509.md`
+- `mydocs/plans/task_m020_30.md`
+- `mydocs/plans/task_m020_30_impl.md`
+- `mydocs/working/task_m020_30_stage{N}.md`
+- `mydocs/report/task_m020_30_report.md`
+
+## 잠정 단계
+
+- **Stage 1 — release 전 최종 검증과 대상 commit 확정**
+  - `origin/main` 최신화, `v0.2.0` tag/release 미존재 확인, manifest/version/release notes 정합성 검증.
+  - 산출물: `mydocs/working/task_m020_30_stage1.md`
+  - 검증 관점: release 생성이 가능한 상태인지, release 대상 SHA가 `origin/main`인지 확인.
+- **Stage 2 — v0.2.0 tag와 GitHub Release 생성**
+  - `v0.2.0` tag 생성, 원격 push, GitHub Release 생성.
+  - 산출물: `mydocs/working/task_m020_30_stage2.md`, Git tag `v0.2.0`, GitHub Release `v0.2.0`
+  - 검증 관점: tag와 release가 정확한 대상 SHA와 release notes로 생성됐는지 확인.
+- **Stage 3 — release 생성 결과 검증과 후속 경계 정리**
+  - `gh release view`, tag 목록, release notes, npm publish 보류 상태를 검증하고 기록.
+  - 산출물: `mydocs/working/task_m020_30_stage3.md`
+  - 검증 관점: release가 공개 상태인지, npm publish와 추가 채널이 실행되지 않았는지 확인.
+
+## 검증 계획
+
+### 단계별 검증
+
+- Stage 1
+  - `git fetch --tags origin --prune`
+  - `git rev-parse origin/main`
+  - `ruby -rjson -e 'JSON.parse(File.read("templates/manifest.json"))'`
+  - `rg -n '0.2.0|v0.2.0|plannedTag|baselineTag|GitHub Release|manifest|migration|pending-release|ready' templates/manifest.json docs/migrations/v0.1.0-to-v0.2.0.md README.md docs/distribution-channels.md docs/releases/v0.2.0.md package.json`
+  - `git tag --list --sort=version:refname`
+  - `gh release list --repo postmelee/hyper-waterfall --limit 20`
+  - `git diff --check`
+- Stage 2
+  - `git tag --list v0.2.0`
+  - `git ls-remote origin refs/tags/v0.2.0`
+  - `gh release view v0.2.0 --repo postmelee/hyper-waterfall --json tagName,name,isDraft,isPrerelease,url,targetCommitish`
+  - `git diff --check`
+- Stage 3
+  - `git tag --list --sort=version:refname`
+  - `gh release view v0.2.0 --repo postmelee/hyper-waterfall`
+  - `gh release list --repo postmelee/hyper-waterfall --limit 20`
+  - `git status --short --branch`
+  - `git diff --check`
+
+### 통합 검증
+
+- `v0.2.0` Git tag가 원격에 존재한다.
+- GitHub Release `v0.2.0`이 존재하고 draft/prerelease가 아니다.
+- GitHub Release 제목이 `v0.2.0 - 배포·업데이트 프로토콜 MVP`다.
+- GitHub Release 본문이 `docs/releases/v0.2.0.md`의 release notes 초안과 일치한다.
+- release 대상 commit이 Stage 1에서 확정한 `origin/main` SHA와 일치한다.
+- npm publish와 추가 배포 채널은 실행하지 않았다.
+- `git status --short`가 PR 준비 전 빈 출력이다.
+- `git diff --check`가 경고 없이 통과한다.
+
+## 리스크
+
+- **잘못된 tag 대상**: `local/task30` 문서 커밋에 tag를 만들면 release 대상이 main 배포 상태와 달라진다. Stage 1에서 `origin/main` SHA를 확정하고 Stage 2에서 그 SHA를 대상으로 tag를 만든다.
+- **중복 release 생성**: tag 또는 GitHub Release가 이미 있으면 생성 명령이 실패하거나 기존 release를 덮어쓸 수 있다. Stage 1에서 미존재를 확인하고, 존재하면 중단한다.
+- **manifest status 혼선**: `release.status`는 현재 `planned`로 유지한다. release 생성 이후 별도 정책 변경이 필요하면 후속 task로 분리한다.
+- **npm publish 오인 실행**: release와 npm publish는 별도 승인 게이트다. 이번 task에서는 npm publish를 실행하지 않는다.
+- **권한/인증 문제**: tag push 또는 GitHub Release 생성 권한이 부족하면 Stage 2에서 중단하고 결과를 보고한다.
+
+## 승인 요청 사항
+
+- release tag 대상을 `local/task30`이 아니라 Stage 1에서 확정한 최신 `origin/main` commit으로 고정하는 방향에 동의?
+- `templates/manifest.json`의 `release.status: planned`를 이번 task에서 변경하지 않는 범위에 동의?
+- Stage 2에서 `git tag v0.2.0`, `git push origin v0.2.0`, `gh release create v0.2.0`를 실행하는 계획에 동의?
+- npm publish, Homebrew/Docker/plugin 배포, root/directory checksum 산식 확정은 제외하는 범위에 동의?
+
+승인되면 `task_m020_30_impl.md`에서 단계별 산출물, 검증 명령, 커밋 메시지를 구체화한다.

--- a/mydocs/plans/task_m020_30_impl.md
+++ b/mydocs/plans/task_m020_30_impl.md
@@ -1,0 +1,177 @@
+# task_m020_30_impl.md - v0.2.0 GitHub Release/tag 생성 구현계획서
+
+수행계획서: [`task_m020_30.md`](task_m020_30.md)
+GitHub Issue: [#30](https://github.com/postmelee/hyper-waterfall/issues/30)
+마일스톤: M020
+
+## 단계 개요
+
+| Stage | 제목 | 주요 산출 | 검증 |
+|---|---|---|---|
+| 1 | release 전 최종 검증과 대상 commit 확정 | `mydocs/working/task_m020_30_stage1.md` | manifest/version/release notes 정합성, tag/release 미존재, release 대상 SHA 기록 |
+| 2 | v0.2.0 tag와 GitHub Release 생성 | `mydocs/working/task_m020_30_stage2.md`, Git tag `v0.2.0`, GitHub Release `v0.2.0` | tag SHA, 원격 tag, release title/body/draft 상태 확인 |
+| 3 | release 생성 결과 검증과 후속 경계 정리 | `mydocs/working/task_m020_30_stage3.md` | release view/list, npm publish 미실행, 최종 상태 확인 |
+
+## Stage 1 — release 전 최종 검증과 대상 commit 확정
+
+### 산출물
+
+신규:
+
+- `mydocs/working/task_m020_30_stage1.md`
+
+수정:
+
+- 없음. Stage 1은 검증 결과와 release 대상 SHA를 단계 보고서에 기록한다.
+
+### 변경 내용
+
+- `origin/main`을 최신화하고 release 대상 commit SHA를 `git rev-parse origin/main`으로 확정한다.
+- `v0.2.0` local tag, remote tag, GitHub Release가 아직 없는지 확인한다.
+- `package.json`, `templates/manifest.json`, `docs/releases/v0.2.0.md`, migration guide, README, distribution strategy의 `0.2.0`/`v0.2.0` 표현을 대조한다.
+- `docs/releases/v0.2.0.md`의 release notes 초안이 Stage 2에서 사용할 수 있는 상태인지 확인한다.
+- `templates/manifest.json`의 `release.status: planned`는 변경하지 않는다.
+
+### 검증
+
+```bash
+git fetch --tags origin --prune
+git rev-parse origin/main
+ruby -rjson -e 'JSON.parse(File.read("templates/manifest.json"))'
+rg -n '0.2.0|v0.2.0|plannedTag|baselineTag|GitHub Release|manifest|migration|pending-release|ready' templates/manifest.json docs/migrations/v0.1.0-to-v0.2.0.md README.md docs/distribution-channels.md docs/releases/v0.2.0.md package.json
+git tag --list --sort=version:refname
+git ls-remote origin refs/tags/v0.2.0
+gh release list --repo postmelee/hyper-waterfall --limit 20
+git diff --check
+```
+
+### 커밋
+
+```text
+Task #30 Stage 1: release 전 최종 검증과 대상 commit 확정
+```
+
+## Stage 2 — v0.2.0 tag와 GitHub Release 생성
+
+### 산출물
+
+신규:
+
+- `mydocs/working/task_m020_30_stage2.md`
+
+외부 산출물:
+
+- local Git tag `v0.2.0`
+- remote Git tag `v0.2.0`
+- GitHub Release `v0.2.0`
+
+임시 산출물:
+
+- `/private/tmp/hyper-waterfall-v0.2.0-release-notes.md`
+
+### 변경 내용
+
+- Stage 1에서 확정한 `origin/main` SHA를 대상으로 `v0.2.0` tag를 생성한다.
+- `git push origin refs/tags/v0.2.0`로 tag를 원격에 게시한다.
+- `docs/releases/v0.2.0.md`의 release notes 초안을 `/private/tmp/hyper-waterfall-v0.2.0-release-notes.md`에 작성한다.
+- `gh release create v0.2.0 --verify-tag --title "v0.2.0 - 배포·업데이트 프로토콜 MVP" --notes-file /private/tmp/hyper-waterfall-v0.2.0-release-notes.md`로 GitHub Release를 생성한다.
+- release 생성 결과와 명령 출력 요약을 `mydocs/working/task_m020_30_stage2.md`에 기록한다.
+
+### 실행 명령
+
+아래 `<RELEASE_SHA>`는 Stage 1에서 확정한 `origin/main` SHA로 치환한다.
+
+```bash
+git tag v0.2.0 <RELEASE_SHA>
+git push origin refs/tags/v0.2.0
+gh release create v0.2.0 --repo postmelee/hyper-waterfall --verify-tag --title "v0.2.0 - 배포·업데이트 프로토콜 MVP" --notes-file /private/tmp/hyper-waterfall-v0.2.0-release-notes.md
+```
+
+### 검증
+
+```bash
+git tag --list v0.2.0
+git rev-list -n 1 v0.2.0
+git ls-remote origin refs/tags/v0.2.0
+gh release view v0.2.0 --repo postmelee/hyper-waterfall --json tagName,name,isDraft,isPrerelease,url,targetCommitish
+git diff --check
+```
+
+### 커밋
+
+```text
+Task #30 Stage 2: v0.2.0 tag와 GitHub Release 생성
+```
+
+## Stage 3 — release 생성 결과 검증과 후속 경계 정리
+
+### 산출물
+
+신규:
+
+- `mydocs/working/task_m020_30_stage3.md`
+
+수정:
+
+- 없음. Stage 3은 생성된 release 검증 결과와 후속 작업 경계를 단계 보고서에 기록한다.
+
+### 변경 내용
+
+- `gh release view v0.2.0`로 release 제목, tag, draft/prerelease 여부, URL, 본문을 확인한다.
+- tag 목록과 remote tag를 다시 확인한다.
+- npm publish, Homebrew, Docker, plugin 배포가 이번 task에서 실행되지 않았음을 보고서에 기록한다.
+- 후속 작업 후보를 npm publish와 M030 배포 채널 작업으로 분리해 기록한다.
+
+### 검증
+
+```bash
+git tag --list --sort=version:refname
+git ls-remote origin refs/tags/v0.2.0
+gh release view v0.2.0 --repo postmelee/hyper-waterfall
+gh release list --repo postmelee/hyper-waterfall --limit 20
+git status --short --branch
+git diff --check
+```
+
+### 커밋
+
+```text
+Task #30 Stage 3: release 생성 결과 검증과 후속 경계 정리
+```
+
+## 검증
+
+- 각 Stage 검증 명령은 단계 보고서 작성 전에 실행한다.
+- 실패한 검증은 단계 완료로 처리하지 않는다.
+- Stage 2는 외부에 tag와 GitHub Release를 생성하는 단계이므로, Stage 1 보고서 승인 후에만 실행한다.
+- `v0.2.0` tag 또는 GitHub Release가 이미 존재하면 Stage 2 생성 명령을 실행하지 않고 작업지시자에게 상태를 보고한다.
+- 계획 변경이 필요하면 구현계획서를 먼저 갱신하고 작업지시자 승인을 받는다.
+
+## 커밋
+
+- 단계 커밋은 단계 보고서와 해당 Stage의 문서 산출물을 묶는다.
+- Stage 2의 외부 산출물인 tag와 GitHub Release는 Git 커밋으로 되돌릴 수 없으므로, 생성 전 검증과 생성 후 검증 결과를 단계 보고서에 자세히 기록한다.
+- 커밋 메시지는 `Task #30 Stage {N}: {핵심 내용 요약}` 형식을 따른다.
+
+## 단계 의존성
+
+- Stage 2는 Stage 1에서 `origin/main` SHA, tag/release 미존재, release notes 초안이 확정된 뒤 진행한다.
+- Stage 3은 Stage 2에서 tag push와 GitHub Release 생성이 성공한 뒤 진행한다.
+- 최종 결과보고서와 PR 게시는 Stage 3 승인 이후 `task-final-report` 절차로 진행한다.
+
+## 위험과 대응
+
+- **잘못된 tag 대상**: `local/task30` 문서 커밋이 아니라 Stage 1에서 확정한 `origin/main` SHA에 tag를 생성한다. Stage 2 검증에서 `git rev-list -n 1 v0.2.0`와 remote tag SHA를 대조한다.
+- **중복 tag/release**: Stage 1에서 local tag, remote tag, GitHub Release 미존재를 확인한다. 존재하면 생성 명령을 실행하지 않는다.
+- **외부 산출물 rollback 비용**: tag push와 GitHub Release는 외부 상태를 만든다. 실패 시 삭제나 수정은 별도 승인 없이 수행하지 않고 상태를 보고한다.
+- **release notes 불일치**: Stage 2에서 임시 notes 파일을 만들고, Stage 3에서 `gh release view` 본문과 `docs/releases/v0.2.0.md` 초안을 대조한다.
+- **npm publish 혼선**: 이번 task에서 npm publish는 실행하지 않는다. `docs/releases/v0.2.0-npm-publish.md` 기준의 publish 승인 게이트는 후속 작업으로 남긴다.
+
+## 승인 요청 사항
+
+- Stage 1~3 분할, 산출물, 검증 명령, 커밋 메시지에 동의?
+- Stage 2에서 `v0.2.0` tag를 Stage 1에서 확정한 `origin/main` SHA에 생성하는 방향에 동의?
+- Stage 2에서 `git push origin refs/tags/v0.2.0`와 `gh release create v0.2.0 --verify-tag`를 실행하는 범위에 동의?
+- `templates/manifest.json`의 `release.status: planned` 유지, npm publish 제외, root/directory checksum 산식 제외 범위에 동의?
+
+승인되면 Stage 1 구현을 시작한다.

--- a/mydocs/report/task_m020_30_report.md
+++ b/mydocs/report/task_m020_30_report.md
@@ -1,0 +1,77 @@
+# task_m020_30_report.md - v0.2.0 GitHub Release/tag 생성 최종 보고서
+
+GitHub Issue: [#30](https://github.com/postmelee/hyper-waterfall/issues/30)
+마일스톤: M020
+
+## 작업 요약
+
+- 대상 이슈: #30
+- 마일스톤: M020
+- 단계 수: 3
+- 작업 목적: `v0.2.0` Git tag와 GitHub Release를 생성해 M020 배포·업데이트 프로토콜 MVP의 canonical 배포 단위를 확정한다.
+
+## 변경 파일 목록과 영향 범위
+
+| 경로 | 변경 요약 | 영향 범위 |
+|---|---|---|
+| `mydocs/orders/20260509.md` | #30 오늘할일 상태를 완료로 갱신 | 작업 추적 |
+| `mydocs/plans/task_m020_30.md` | release 생성 수행계획서 작성 | 작업 계획 |
+| `mydocs/plans/task_m020_30_impl.md` | 3단계 구현계획과 검증 기준 작성 | 작업 계획 |
+| `mydocs/working/task_m020_30_stage1.md` | release 전 최종 검증과 대상 SHA 확정 결과 기록 | 단계 보고 |
+| `mydocs/working/task_m020_30_stage2.md` | tag push와 GitHub Release 생성 결과 기록 | 단계 보고, 외부 산출물 추적 |
+| `mydocs/working/task_m020_30_stage3.md` | release 생성 결과 재검증과 후속 경계 기록 | 단계 보고 |
+| `mydocs/report/task_m020_30_report.md` | 최종 결과와 수용 기준 검증 정리 | 최종 보고 |
+
+외부 산출물:
+
+| 산출물 | 결과 |
+|---|---|
+| Git tag `v0.2.0` | `9bd2439b411f76b9d4360569e2f32e0d7976816f`에 생성 후 원격 push 완료 |
+| GitHub Release `v0.2.0` | [`v0.2.0 - 배포·업데이트 프로토콜 MVP`](https://github.com/postmelee/hyper-waterfall/releases/tag/v0.2.0) 공개 완료 |
+
+## 변경 전·후 정량 비교
+
+| 지표 | 변경 전 | 변경 후 |
+|---|---|---|
+| Task #30 작업 문서 | 0개 | 수행계획서 1개, 구현계획서 1개, 단계 보고서 3개, 최종 보고서 1개 |
+| `v0.2.0` local/remote tag | 없음 | `9bd2439b411f76b9d4360569e2f32e0d7976816f` 대상 tag 존재 |
+| GitHub Release `v0.2.0` | 없음 | 공개 release 존재, draft `false`, prerelease `false` |
+| GitHub Release 제목 | 해당 없음 | `v0.2.0 - 배포·업데이트 프로토콜 MVP` |
+| npm publish | 실행 전 | 실행하지 않음 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 |
+|---|---|
+| `v0.2.0` Git tag가 원격에 존재한다 | OK — `git ls-remote origin refs/tags/v0.2.0` 결과가 `9bd2439b411f76b9d4360569e2f32e0d7976816f refs/tags/v0.2.0` |
+| GitHub Release `v0.2.0`이 존재하고 draft/prerelease가 아니다 | OK — `gh release view` JSON에서 `isDraft: false`, `isPrerelease: false` |
+| GitHub Release 제목이 계획과 일치한다 | OK — `v0.2.0 - 배포·업데이트 프로토콜 MVP` |
+| GitHub Release 본문이 release notes 초안과 일치한다 | OK — `gh release view --json body --jq .body` 출력과 `/private/tmp/hyper-waterfall-v0.2.0-release-notes.md` 내용 일치 |
+| release 대상 commit이 Stage 1에서 확정한 `origin/main` SHA와 일치한다 | OK — `git rev-list -n 1 v0.2.0` 결과가 `9bd2439b411f76b9d4360569e2f32e0d7976816f` |
+| npm publish와 추가 배포 채널은 실행하지 않았다 | OK — 단계 보고서와 Git 변경 범위 모두 release/tag 생성만 기록 |
+| `git status --short`가 PR 준비 전 빈 출력이다 | OK — 최종 보고서 작성 전 빈 출력 확인 |
+| `git diff --check`가 경고 없이 통과한다 | OK — 최종 보고서 작성 전 출력 없이 통과 |
+
+### 단계별 검증 결과
+
+- Stage 1: [`task_m020_30_stage1.md`](../working/task_m020_30_stage1.md) — release 대상 `origin/main` SHA 확정, tag/release 미존재, manifest/version/release notes 정합성 확인.
+- Stage 2: [`task_m020_30_stage2.md`](../working/task_m020_30_stage2.md) — `v0.2.0` tag 생성, 원격 push, GitHub Release 공개 생성 확인.
+- Stage 3: [`task_m020_30_stage3.md`](../working/task_m020_30_stage3.md) — release view/list 재검증, npm publish와 후속 배포 채널 제외 범위 기록.
+
+## 잔여 위험과 후속 작업
+
+### 잔여 위험
+
+- npm publish는 아직 실행하지 않았다.
+- root/directory checksum 공식 산식은 아직 확정하지 않았다.
+- GitHub Release는 이미 공개됐으므로, 수정·삭제가 필요하면 별도 승인 후 처리해야 한다.
+
+### 후속 작업 후보
+
+- `docs/releases/v0.2.0-npm-publish.md` 기준으로 npm publish 승인 게이트를 통과한 뒤 별도 task에서 publish 진행.
+- M030 이후 Homebrew formula/tap, Docker image, Codex plugin, Claude plugin packaging 이슈를 별도 추적.
+- root/directory checksum 공식 산식 확정 후 manifest 상태 갱신 여부 검토.
+
+## 작업지시자 승인 요청
+
+- 최종 보고서와 수용 기준 검증 결과를 승인하면 PR 게시 절차로 진행한다.

--- a/mydocs/working/task_m020_30_stage1.md
+++ b/mydocs/working/task_m020_30_stage1.md
@@ -1,0 +1,93 @@
+# task_m020_30_stage1.md - release 전 최종 검증과 대상 commit 확정 완료보고서
+
+GitHub Issue: [#30](https://github.com/postmelee/hyper-waterfall/issues/30)
+구현계획서: [`task_m020_30_impl.md`](../plans/task_m020_30_impl.md)
+Stage: 1
+
+## 단계 목적
+
+Stage 1은 `v0.2.0` Git tag와 GitHub Release를 만들기 전에 release 대상 commit을 확정하고, tag/release 중복 여부와 manifest/version/release notes 정합성을 검증하는 단계다. 이 단계에서는 tag, GitHub Release, npm publish를 생성하거나 실행하지 않는다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `mydocs/working/task_m020_30_stage1.md` | release 전 최종 검증 결과, release 대상 SHA, tag/release 미존재 상태 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+소스와 release 문서는 수정하지 않았다. 신규 단계 보고서만 추가했다.
+
+## release 대상 commit
+
+| 항목 | SHA |
+|---|---|
+| release 대상 `origin/main` | `9bd2439b411f76b9d4360569e2f32e0d7976816f` |
+| 현재 `local/task30` HEAD | `e1895c4acfa1d889fbe3068993f9e21a34451654` |
+
+`local/task30` HEAD에는 수행계획서와 구현계획서 커밋이 포함되어 있으므로 release 대상이 아니다. Stage 2에서 `v0.2.0` tag는 `9bd2439b411f76b9d4360569e2f32e0d7976816f`에 생성해야 한다.
+
+## 정합성 확인
+
+manifest/version 상태:
+
+| 항목 | 값 |
+|---|---|
+| `package.json` version | `0.2.0` |
+| manifest `frameworkVersion` | `0.2.0` |
+| manifest `plannedTag` | `v0.2.0` |
+| manifest `baselineTag` | `v0.1.0` |
+| manifest `release.status` | `planned` |
+| root checksum | `pending-release` |
+| `kind: directory` checksum | `pending-release` 3개 |
+| `kind: file` checksum | `ready` 12개 |
+| `kind: symlink` checksum | `not-applicable` 2개 |
+
+release notes 초안은 `docs/releases/v0.2.0.md`에 존재하며, 제목은 `v0.2.0 - 배포·업데이트 프로토콜 MVP`다. 본문 초안에는 `요약`, `주요 변경`, `업데이트 기준`, `보류` 섹션이 있다.
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+git fetch --tags origin --prune
+git rev-parse origin/main
+ruby -rjson -e 'JSON.parse(File.read("templates/manifest.json"))'
+rg -n '0.2.0|v0.2.0|plannedTag|baselineTag|GitHub Release|manifest|migration|pending-release|ready' templates/manifest.json docs/migrations/v0.1.0-to-v0.2.0.md README.md docs/distribution-channels.md docs/releases/v0.2.0.md package.json
+git tag --list --sort=version:refname
+git ls-remote origin refs/tags/v0.2.0
+gh release list --repo postmelee/hyper-waterfall --limit 20
+git diff --check
+```
+
+결과:
+
+- OK: `git fetch --tags origin --prune` 통과.
+- OK: `git rev-parse origin/main` 결과는 `9bd2439b411f76b9d4360569e2f32e0d7976816f`.
+- OK: `templates/manifest.json` JSON parse 통과.
+- OK: 통합 `rg`가 `0.2.0`, `v0.2.0`, `plannedTag`, `baselineTag`, `GitHub Release`, `manifest`, `migration`, `pending-release`, `ready` 표현을 확인했다.
+- OK: `git tag --list --sort=version:refname` 빈 출력. local tag 없음.
+- OK: `git ls-remote origin refs/tags/v0.2.0` 빈 출력. remote `v0.2.0` tag 없음.
+- OK: `gh release list --repo postmelee/hyper-waterfall --limit 20` 빈 출력. GitHub Release 없음.
+- OK: `git diff --check` 출력 없이 통과.
+
+추가 확인:
+
+- OK: release notes 초안 위치와 제목 확인.
+- OK: `local/task30` HEAD와 `origin/main` SHA가 다르므로 release tag 대상은 `origin/main`으로 고정해야 함을 확인.
+
+## 잔여 위험
+
+- Stage 2는 외부에 tag와 GitHub Release를 생성하므로, 실행 후 삭제/수정이 필요하면 별도 승인 없이는 처리하지 않는다.
+- `templates/manifest.json`의 `release.status`는 이번 task에서 `planned`로 유지한다.
+- npm publish는 이번 task에서 실행하지 않는다.
+
+## 다음 단계 영향
+
+- Stage 2에서 사용할 release 대상 SHA는 `9bd2439b411f76b9d4360569e2f32e0d7976816f`다.
+- Stage 2에서는 이 SHA를 대상으로 `git tag v0.2.0 9bd2439b411f76b9d4360569e2f32e0d7976816f`를 실행한다.
+- GitHub Release notes는 `docs/releases/v0.2.0.md`의 release notes 초안을 `/private/tmp/hyper-waterfall-v0.2.0-release-notes.md`로 추출해 사용한다.
+
+## 승인 요청
+
+- Stage 1 산출물과 검증 결과를 승인하면 Stage 2로 진행한다.

--- a/mydocs/working/task_m020_30_stage2.md
+++ b/mydocs/working/task_m020_30_stage2.md
@@ -1,0 +1,96 @@
+# task_m020_30_stage2.md - v0.2.0 tag와 GitHub Release 생성 완료보고서
+
+GitHub Issue: [#30](https://github.com/postmelee/hyper-waterfall/issues/30)
+구현계획서: [`task_m020_30_impl.md`](../plans/task_m020_30_impl.md)
+Stage: 2
+
+## 단계 목적
+
+Stage 2는 Stage 1에서 확정한 `origin/main` commit에 `v0.2.0` tag를 생성하고, 해당 tag를 기준으로 GitHub Release `v0.2.0`을 publish하는 단계다.
+
+## 산출물
+
+| 파일/산출물 | 변경 요약 |
+|---|---|
+| Git tag `v0.2.0` | `9bd2439b411f76b9d4360569e2f32e0d7976816f` commit에 local tag 생성 |
+| remote Git tag `v0.2.0` | `origin`에 `refs/tags/v0.2.0` push 완료 |
+| GitHub Release `v0.2.0` | `v0.2.0 - 배포·업데이트 프로토콜 MVP` 제목으로 publish 완료 |
+| `/private/tmp/hyper-waterfall-v0.2.0-release-notes.md` | `docs/releases/v0.2.0.md`의 release notes 초안을 기준으로 만든 임시 notes 파일 |
+| `mydocs/working/task_m020_30_stage2.md` | tag/release 생성 명령, 검증 결과, 잔여 위험 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+repository 파일은 단계 보고서만 추가했다. `templates/manifest.json`의 `release.status`는 계획대로 `planned`에서 변경하지 않았다. npm publish, Homebrew/Docker/plugin 배포, root/directory checksum 산식 확정은 실행하지 않았다.
+
+## 실행 결과
+
+release 대상 SHA:
+
+```text
+9bd2439b411f76b9d4360569e2f32e0d7976816f
+```
+
+실행 명령:
+
+```bash
+git tag v0.2.0 9bd2439b411f76b9d4360569e2f32e0d7976816f
+git push origin refs/tags/v0.2.0
+gh release create v0.2.0 --repo postmelee/hyper-waterfall --verify-tag --title "v0.2.0 - 배포·업데이트 프로토콜 MVP" --notes-file /private/tmp/hyper-waterfall-v0.2.0-release-notes.md
+```
+
+결과:
+
+- OK: local tag `v0.2.0` 생성.
+- OK: remote tag `v0.2.0` push.
+- OK: GitHub Release 생성.
+- URL: `https://github.com/postmelee/hyper-waterfall/releases/tag/v0.2.0`
+
+GitHub Release 상태:
+
+| 항목 | 값 |
+|---|---|
+| tag | `v0.2.0` |
+| title | `v0.2.0 - 배포·업데이트 프로토콜 MVP` |
+| draft | `false` |
+| prerelease | `false` |
+| targetCommitish | `main` |
+| created | `2026-05-08T19:01:36Z` |
+| published | `2026-05-08T20:34:07Z` |
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+git tag --list v0.2.0
+git rev-list -n 1 v0.2.0
+git ls-remote origin refs/tags/v0.2.0
+gh release view v0.2.0 --repo postmelee/hyper-waterfall --json tagName,name,isDraft,isPrerelease,url,targetCommitish
+git diff --check
+```
+
+결과:
+
+- OK: `git tag --list v0.2.0` 출력이 `v0.2.0`.
+- OK: `git rev-list -n 1 v0.2.0` 출력이 `9bd2439b411f76b9d4360569e2f32e0d7976816f`.
+- OK: `git ls-remote origin refs/tags/v0.2.0` 출력이 `9bd2439b411f76b9d4360569e2f32e0d7976816f	refs/tags/v0.2.0`.
+- OK: `gh release view` JSON 기준 `tagName: v0.2.0`, `name: v0.2.0 - 배포·업데이트 프로토콜 MVP`, `isDraft: false`, `isPrerelease: false`, `url: https://github.com/postmelee/hyper-waterfall/releases/tag/v0.2.0`.
+- OK: `gh release view` 본문이 임시 release notes 파일 내용과 일치.
+- OK: `git diff --check` 출력 없이 통과.
+
+## 잔여 위험
+
+- `targetCommitish`는 GitHub Release API에서 `main`으로 표시되지만, 실제 tag SHA는 `9bd2439b411f76b9d4360569e2f32e0d7976816f`로 검증했다.
+- `templates/manifest.json`의 `release.status`는 이번 task에서 `planned`로 유지했다.
+- npm publish는 아직 실행하지 않았다.
+- root/directory checksum 공식 산식은 아직 확정하지 않았다.
+
+## 다음 단계 영향
+
+- Stage 3에서는 release view/list, local/remote tag, npm publish 미실행 상태를 재검증한다.
+- 최종 보고서에는 GitHub Release URL과 tag SHA를 포함해야 한다.
+- npm publish는 `docs/releases/v0.2.0-npm-publish.md` 기준으로 별도 승인 후 진행한다.
+
+## 승인 요청
+
+- Stage 2 산출물과 검증 결과를 승인하면 Stage 3으로 진행한다.

--- a/mydocs/working/task_m020_30_stage3.md
+++ b/mydocs/working/task_m020_30_stage3.md
@@ -1,0 +1,80 @@
+# task_m020_30_stage3.md - release 생성 결과 검증과 후속 경계 정리 완료보고서
+
+GitHub Issue: [#30](https://github.com/postmelee/hyper-waterfall/issues/30)
+구현계획서: [`task_m020_30_impl.md`](../plans/task_m020_30_impl.md)
+Stage: 3
+
+## 단계 목적
+
+Stage 3은 Stage 2에서 생성한 `v0.2.0` Git tag와 GitHub Release를 다시 검증하고, npm publish와 후속 배포 채널이 이번 task 범위 밖임을 명확히 기록하는 단계다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `mydocs/working/task_m020_30_stage3.md` | release view/list, local/remote tag, npm publish 보류 경계, 후속 작업 후보 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+소스와 release 문서는 수정하지 않았다. 신규 단계 보고서만 추가했다. Stage 3에서는 npm publish, Homebrew, Docker, plugin 배포를 실행하지 않았다.
+
+## release 검증 요약
+
+| 항목 | 값 |
+|---|---|
+| Git tag | `v0.2.0` |
+| tag SHA | `9bd2439b411f76b9d4360569e2f32e0d7976816f` |
+| Release title | `v0.2.0 - 배포·업데이트 프로토콜 MVP` |
+| Release URL | `https://github.com/postmelee/hyper-waterfall/releases/tag/v0.2.0` |
+| draft | `false` |
+| prerelease | `false` |
+| release list 표시 | `Latest` |
+| published | `2026-05-08T20:34:07Z` |
+
+GitHub Release 본문은 `docs/releases/v0.2.0.md`의 release notes 초안에서 만든 임시 notes 파일 내용과 일치한다.
+
+## 후속 경계
+
+- npm publish는 이번 task에서 실행하지 않았다.
+- npm publish는 `docs/releases/v0.2.0-npm-publish.md`의 publish 전 승인 게이트를 기준으로 별도 승인 후 진행한다.
+- Homebrew formula/tap, Docker image, Codex plugin, Claude plugin packaging은 M030 이후 별도 이슈에서 추적한다.
+- root/directory checksum 공식 산식은 이번 task에서 확정하지 않았다.
+- `templates/manifest.json`의 `release.status`는 이번 task에서 `planned`로 유지했다.
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+git tag --list --sort=version:refname
+git ls-remote origin refs/tags/v0.2.0
+gh release view v0.2.0 --repo postmelee/hyper-waterfall
+gh release list --repo postmelee/hyper-waterfall --limit 20
+git status --short --branch
+git diff --check
+```
+
+결과:
+
+- OK: `git tag --list --sort=version:refname` 출력에 `v0.2.0`이 있다.
+- OK: `git ls-remote origin refs/tags/v0.2.0` 출력이 `9bd2439b411f76b9d4360569e2f32e0d7976816f	refs/tags/v0.2.0`.
+- OK: `gh release view v0.2.0`에서 title `v0.2.0 - 배포·업데이트 프로토콜 MVP`, tag `v0.2.0`, draft `false`, prerelease `false`, URL을 확인했다.
+- OK: `gh release list --repo postmelee/hyper-waterfall --limit 20`에서 `v0.2.0 - 배포·업데이트 프로토콜 MVP`가 `Latest`로 표시된다.
+- OK: `git status --short --branch` 결과는 `local/task30...origin/main [ahead 4]`이고 미커밋 변경은 Stage 3 보고서뿐이다.
+- OK: `git diff --check` 출력 없이 통과.
+
+## 잔여 위험
+
+- npm publish는 아직 실행하지 않았다.
+- root/directory checksum 공식 산식은 아직 확정하지 않았다.
+- GitHub Release는 이미 publish됐으므로, 수정·삭제가 필요하면 별도 승인 후 처리해야 한다.
+
+## 다음 단계 영향
+
+- 최종 결과보고서와 PR 게시 단계에서는 `task-final-report` 절차를 적용한다.
+- 최종 보고서에는 `v0.2.0` tag SHA, Release URL, npm publish 미실행 상태를 기록해야 한다.
+- Task #30 PR은 release 실행 기록과 작업 문서를 `main`에 남기는 목적이다. release tag 자체는 이미 `origin/main`의 `9bd2439b411f76b9d4360569e2f32e0d7976816f`를 가리킨다.
+
+## 승인 요청
+
+- Stage 3 산출물과 검증 결과를 승인하면 최종 결과보고서와 PR 게시 단계로 진행한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #30 v0.2.0 GitHub Release/tag 생성 기록과 검증 산출물 정리
- 왜: M020 배포·업데이트 프로토콜 MVP의 canonical 배포 단위를 GitHub tag/release로 확정하기 위해
- 무엇: `v0.2.0` tag와 GitHub Release 생성 결과, 단계 보고서, 최종 보고서, 오늘할일 완료 상태를 기록
- 리뷰 포인트: release tag 대상이 `origin/main`의 `9bd2439b411f76b9d4360569e2f32e0d7976816f`인지, npm publish 제외 경계가 명확한지

## 변경 내역

- **계획/최종 보고** ([bf4a009](https://github.com/postmelee/hyper-waterfall/commit/bf4a00998b7e017bcc89aff0c3353c2bd44ee067), [e1895c4](https://github.com/postmelee/hyper-waterfall/commit/e1895c4acfa1d889fbe3068993f9e21a34451654), [001cc98](https://github.com/postmelee/hyper-waterfall/commit/001cc98f3365873ffb88d13a738ad15a9e1d0e69)): 수행계획서, 구현계획서, 최종 보고서, 오늘할일 완료 상태 작성
- **[Stage 1](https://github.com/postmelee/hyper-waterfall/blob/001cc98f3365873ffb88d13a738ad15a9e1d0e69/mydocs/working/task_m020_30_stage1.md)** ([5f64f3f](https://github.com/postmelee/hyper-waterfall/commit/5f64f3fb418a169d39155ad8cfc319b900a91518)): release 전 최종 검증과 release 대상 `origin/main` SHA 확정
- **[Stage 2](https://github.com/postmelee/hyper-waterfall/blob/001cc98f3365873ffb88d13a738ad15a9e1d0e69/mydocs/working/task_m020_30_stage2.md)** ([9d72bcd](https://github.com/postmelee/hyper-waterfall/commit/9d72bcd623905d786b67608d3ec6f4e9c48274e5)): `v0.2.0` tag push와 GitHub Release 생성 결과 기록
- **[Stage 3](https://github.com/postmelee/hyper-waterfall/blob/001cc98f3365873ffb88d13a738ad15a9e1d0e69/mydocs/working/task_m020_30_stage3.md)** ([370773e](https://github.com/postmelee/hyper-waterfall/commit/370773e638162c9e686c97734b8ae247eea7a8bf)): release 생성 결과 재검증과 후속 배포 경계 정리

### 작업 문서

- 수행 계획서: [task_m020_30.md](https://github.com/postmelee/hyper-waterfall/blob/001cc98f3365873ffb88d13a738ad15a9e1d0e69/mydocs/plans/task_m020_30.md)
- 구현 계획서: [task_m020_30_impl.md](https://github.com/postmelee/hyper-waterfall/blob/001cc98f3365873ffb88d13a738ad15a9e1d0e69/mydocs/plans/task_m020_30_impl.md)
- 최종 보고서: [task_m020_30_report.md](https://github.com/postmelee/hyper-waterfall/blob/001cc98f3365873ffb88d13a738ad15a9e1d0e69/mydocs/report/task_m020_30_report.md)

## 핵심 리뷰 포인트

- `v0.2.0` tag가 `local/task30` 문서 커밋이 아니라 release 대상 `origin/main` SHA에 생성됐는지
- GitHub Release 제목, 공개 상태, release notes 본문이 계획과 일치하는지
- npm publish, Homebrew, Docker, plugin packaging이 이번 task 범위에서 제외된 점이 명확한지

## 검증

### 자동 검증

| 주제 | 검증 방법 | 결과 | 근거 |
|------|-----------|------|------|
| 작업트리와 공백 오류 | `git status --short`, `git diff --check` | OK | 최종 보고서 작성 전 작업트리 빈 출력, `git diff --check` 출력 없음 |
| local tag 대상 SHA | `git rev-list -n 1 v0.2.0` | OK | `9bd2439b411f76b9d4360569e2f32e0d7976816f` |
| Release notes 본문 | `gh release view v0.2.0 --json body --jq .body`와 임시 notes 파일 대조 | OK | GitHub Release 본문과 `/private/tmp/hyper-waterfall-v0.2.0-release-notes.md` 내용 일치 |

### 수동/시나리오 검증

| 시나리오 | 확인 절차 | 결과 | 자료 |
|----------|-----------|------|------|
| 단계 보고서 검토 | Stage 1~3 보고서의 실행 명령, 결과, 잔여 위험을 최종 보고서 수용 기준과 대조 | OK | [task_m020_30_report.md](https://github.com/postmelee/hyper-waterfall/blob/001cc98f3365873ffb88d13a738ad15a9e1d0e69/mydocs/report/task_m020_30_report.md) |

### CI/원격 검증

| 항목 | 결과 | 근거 |
|------|------|------|
| 원격 tag | OK | `git ls-remote origin refs/tags/v0.2.0` 결과가 `9bd2439b411f76b9d4360569e2f32e0d7976816f refs/tags/v0.2.0` |
| GitHub Release metadata | OK | `gh release view` 기준 tag `v0.2.0`, title `v0.2.0 - 배포·업데이트 프로토콜 MVP`, draft `false`, prerelease `false` |
| GitHub Release 목록 | OK | `gh release list --limit 5`에서 `v0.2.0 - 배포·업데이트 프로토콜 MVP`가 `Latest`로 표시 |

### 검증 한계

- npm publish는 이번 task 범위에서 제외되어 실행하지 않았다.
- Homebrew, Docker, Codex plugin, Claude plugin packaging은 후속 이슈에서 별도 추적한다.
- PR 생성 전 본문이므로 GitHub Actions PR check 결과는 포함하지 않았다.

## 관련 이슈

- #24
- #26
- #21
- #22

## 후속 이슈 제안

- `docs/releases/v0.2.0-npm-publish.md` 기준 npm publish 승인 게이트 진행
- M030 이후 Homebrew formula/tap, Docker image, Codex plugin, Claude plugin packaging 분리 추적
- root/directory checksum 공식 산식 확정 후 manifest 상태 갱신 검토

## 남은 리스크

- GitHub Release는 이미 공개됐으므로 수정·삭제가 필요하면 별도 승인 후 처리해야 한다.
- `templates/manifest.json`의 `release.status`는 이번 task 범위에 따라 `planned`로 유지했다.
