### PR TITLE
Task #35: Homebrew public tap 배포와 설치 안내

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,16 @@ npx hyper-waterfall update --repo . --from v0.1.0 --to v0.2.0 --dry-run
 npx hyper-waterfall doctor --repo .
 ```
 
+macOS에서는 Homebrew public tap으로 CLI를 설치할 수 있습니다.
+
+```bash
+brew install postmelee/tap/hyper-waterfall
+hyper-waterfall --version
+hyper-waterfall doctor --repo .
+```
+
+이 Homebrew formula는 npm CLI를 설치하는 wrapper이며, canonical 기준인 GitHub Release/tag, `templates/manifest.json`, migration guide를 대체하지 않습니다. Homebrew는 Node runtime을 의존성으로 설치할 수 있습니다. 아무 tap도 지정하지 않는 `brew install hyper-waterfall` 경로는 Homebrew core 등재가 필요하므로 [#46](https://github.com/postmelee/hyper-waterfall/issues/46)에서 별도로 검토합니다.
+
 ## 도입 후 작업 흐름
 
 Hyper-Waterfall은 **타스크** 단위로 작업을 진행합니다.

--- a/docs/distribution-channels.md
+++ b/docs/distribution-channels.md
@@ -110,10 +110,10 @@ Hyper-Waterfall의 배포 원천은 GitHub Release/tag다. Release는 다음 기
 
 판단:
 
-- 다음 구현 후보로 가장 현실적이다.
-- 단, 실제 구현은 `v0.2.0` release/tag와 npm package 배포 기준이 안정된 뒤 진행한다.
-- formula/tap PoC의 최소 범위와 접근안 비교는 [`docs/homebrew-formula-tap-poc.md`](homebrew-formula-tap-poc.md)에 둔다.
-- 후속 마일스톤 후보: `M030 - Homebrew formula/tap PoC`.
+- `postmelee/homebrew-tap` public tap이 생성됐고, `postmelee/tap/hyper-waterfall` 공개 설치 smoke가 통과했다.
+- 사용자-facing 설치 명령은 `brew install postmelee/tap/hyper-waterfall`이다. 이 명령은 Homebrew가 tap을 자동으로 추가하고 formula를 설치하는 한 줄 경로다.
+- 아무 tap도 지정하지 않는 `brew install hyper-waterfall` 첫 설치 경로는 Homebrew core 등재가 필요하므로 [#46](https://github.com/postmelee/hyper-waterfall/issues/46)에서 별도로 검토한다.
+- formula/tap PoC와 public smoke 결과는 [`docs/homebrew-formula-tap-poc.md`](homebrew-formula-tap-poc.md)와 `mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md`에 둔다.
 
 ### Docker
 
@@ -200,7 +200,7 @@ Hyper-Waterfall의 배포 원천은 GitHub Release/tag다. Release는 다음 기
 |---|---|---|---|
 | P0 | GitHub Release/tag + manifest + migration guide 유지 | canonical 기준이 흔들리면 모든 채널이 갈라진다. | release checklist, checksum, migration guide 유지 |
 | P0 | npm CLI 안정화 | 다른 실행 채널이 재사용할 최소 실행 계층이다. | `init/update/doctor` 출력 계약 유지, test 유지 |
-| P1 | Homebrew formula/tap | macOS 개발자 설치 경험 개선 효과가 크고 Docker/plugin보다 운영 모델이 단순하다. | 실제 release/tag, npm publish 또는 release asset 전략 확정 |
+| P1 | Homebrew formula/tap | macOS 개발자 설치 경험 개선 효과가 크고 Docker/plugin보다 운영 모델이 단순하다. | public tap smoke 통과. core 등재 가능성은 #46에서 별도 검토 |
 | P2 | Docker read-only image | CI와 격리 실행 가치가 있지만 volume/path 검증 비용이 있다. | CLI read-only 보장, image tag/version 정책 확정 |
 | P3 | Codex plugin packaging 검증 | agent UI 통합 가치는 크지만 사양 변화와 lock-in 위험이 있다. | plugin packaging 사양 확인, canonical 문서 참조 방식 확정 |
 | P3 | Claude plugin packaging 검증 | Codex와 같은 가치를 갖지만 중복 구현 위험이 있다. | 공통 plugin 원칙 확정, Claude Code 진입 방식 검증 |
@@ -208,7 +208,7 @@ Hyper-Waterfall의 배포 원천은 GitHub Release/tag다. Release는 다음 기
 권장 순서:
 
 1. P0: `v0.2.0` GitHub Release/tag와 npm CLI publish 준비를 안정화한다.
-2. P1: Homebrew formula/tap PoC를 별도 이슈로 진행한다.
+2. P1: Homebrew public tap은 `postmelee/tap/hyper-waterfall` 경로로 유지하고, core 등재 가능성은 #46에서 별도로 평가한다.
 3. P2: Docker는 `doctor`와 `update --dry-run` read-only image부터 검증한다.
 4. P3: Codex plugin과 Claude plugin은 packaging 검증 task를 먼저 만들고, 실제 배포는 그 결과를 보고 분리한다.
 
@@ -219,7 +219,7 @@ Hyper-Waterfall의 배포 원천은 GitHub Release/tag다. Release는 다음 기
 | 후보 | 범위 | 제외 |
 |---|---|---|
 | M020 - npm publish 준비 | npm package publish checklist, tag/release 정합성, publish 전 검증 | Homebrew, Docker, plugin 구현, 승인 없는 publish |
-| M030 - Homebrew formula/tap PoC | `hyper-waterfall` CLI 설치, version 확인, `doctor` smoke | 자동 release pipeline |
+| M040 - Homebrew public tap 배포 | `postmelee/tap/hyper-waterfall` 설치, version 확인, `doctor` smoke | 자동 release pipeline, Homebrew core 제출 |
 | M030 - Docker read-only CLI image PoC | `doctor`, `init --dry-run`, `update --dry-run` 실행 image | host 파일 자동 수정 |
 | M030 - Codex plugin packaging 검증 | Codex plugin bundle 구조, canonical 문서 참조 방식, fallback 확인 | 실제 public 배포 |
 | M030 - Claude plugin packaging 검증 | Claude plugin bundle 구조, `.claude/skills`와 canonical 문서 참조 방식 확인 | 실제 public 배포 |
@@ -228,7 +228,7 @@ Hyper-Waterfall의 배포 원천은 GitHub Release/tag다. Release는 다음 기
 
 보류:
 
-- Homebrew formula 구현은 이번 task에서 하지 않는다.
+- Homebrew core 제출은 이번 task에서 하지 않는다. `brew install hyper-waterfall` 첫 설치 경로는 #46에서 별도 검토한다.
 - Docker image 구현은 이번 task에서 하지 않는다.
 - Codex plugin과 Claude plugin 실제 packaging과 배포는 이번 task에서 하지 않는다.
 - 자동 릴리스 파이프라인은 이번 task에서 하지 않는다.

--- a/docs/homebrew-formula-tap-poc.md
+++ b/docs/homebrew-formula-tap-poc.md
@@ -159,19 +159,21 @@ brew test postmelee/tap/hyper-waterfall
 
 ## public tap 배포 승인 게이트
 
-다음 항목이 모두 충족되기 전에는 public tap을 만들거나 formula를 push하지 않는다.
+Task #35에서 public tap 배포와 공개 설치 smoke를 실행했다. 다음 항목은 public tap 생성과 formula push 전 승인 게이트였으며, 현재 상태를 함께 기록한다.
 
-- [ ] 작업지시자가 Homebrew tap 공개 배포를 명시 승인했다.
+- [x] 작업지시자가 Homebrew tap 공개 배포를 명시 승인했다.
 - [x] `v0.2.0` GitHub Release/tag와 npm package version 정합성을 확인했다.
 - [x] npm tarball 또는 release asset SHA256을 확인했다.
 - [x] local tap에서 `brew install --build-from-source`가 통과했다.
+- [x] public tap repository `postmelee/homebrew-tap`을 생성하고 `Formula/hyper-waterfall.rb`를 push했다.
+- [x] public tap에서 `brew install --build-from-source`가 통과했다.
 - [x] `hyper-waterfall --version` smoke가 통과했다.
 - [x] `hyper-waterfall doctor --repo .` smoke가 read-only로 동작했다.
 - [x] `brew test`가 통과했다.
-- [ ] README 또는 release notes에 Homebrew 설치 안내를 추가할지 별도 승인했다.
+- [x] README 또는 release notes에 Homebrew 설치 안내를 추가할지 별도 승인했다.
 - [ ] formula 업데이트 자동화 여부를 별도 이슈로 분리했다.
 
-Task #34 결과 기준으로 local technical smoke는 통과했지만 public tap 배포는 아직 보류한다. 남은 보류 조건은 public tap 배포 승인, tap repository 이름과 공개 범위, README 또는 release notes 안내 승인, formula 업데이트 운영 방식, Homebrew `node` 의존성 안내다.
+Task #35 결과 기준으로 public tap technical smoke는 통과했다. 사용자-facing 설치 명령은 `brew install postmelee/tap/hyper-waterfall`이다. 아무 tap도 지정하지 않는 `brew install hyper-waterfall` 첫 설치 경로는 Homebrew core 등재가 필요하므로 [#46](https://github.com/postmelee/hyper-waterfall/issues/46)에서 별도로 검토한다.
 
 ## 운영 비용
 
@@ -186,11 +188,7 @@ Task #34 결과 기준으로 local technical smoke는 통과했지만 public tap
 
 ## 후속 작업 후보
 
-- `homebrew-tap` 저장소 이름과 공개 범위 결정
-- Task #34에서 확인한 tarball SHA256과 formula 후보를 public tap 후보로 이관
-- public tap 기준 `brew audit --new --formula` 재실행
-- public tap 기준 macOS install smoke 검증
-- README에 Homebrew 설치 안내를 넣을지 판단
+- Homebrew core 등재 가능성 평가와 제출 준비: [#46](https://github.com/postmelee/hyper-waterfall/issues/46)
 - release마다 formula를 갱신하는 수동 checklist 또는 자동화 이슈 등록
 
 ## 수용 기준 점검
@@ -200,10 +198,10 @@ Task #34 결과 기준으로 local technical smoke는 통과했지만 public tap
 | Homebrew가 해결하는 사용자 문제와 비목표가 명확하다. | `목적`과 `비목표`에서 macOS 설치 발견성 개선과 제외 범위를 분리했다. |
 | PoC에서 검증할 설치 경로와 smoke 명령이 명확하다. | `smoke 검증 경로`에서 local PoC 명령 후보와 `hyper-waterfall --version`, `hyper-waterfall doctor --repo .`, `brew test` 기대 결과를 정리했다. |
 | formula가 canonical 기준을 대체하지 않고 CLI 실행 수단으로만 동작한다는 경계가 드러난다. | `책임 경계`, `version과 checksum 기준`, `추천 PoC`에서 GitHub Release/tag, manifest, migration guide와 Homebrew wrapper의 역할을 분리했다. |
-| 실제 public 배포 여부는 별도 승인 지점으로 남는다. | `public tap 배포 승인 게이트`에서 tap 공개, formula push, README 안내, 자동화 여부를 별도 승인 항목으로 남겼다. |
+| 실제 public 배포 실행과 남은 운영 자동화가 승인 지점으로 분리되어 있다. | `public tap 배포 승인 게이트`에서 Task #35의 tap 공개, formula push, README 안내 승인 상태를 기록하고, formula 업데이트 자동화는 별도 항목으로 남겼다. |
 
 ## 결론
 
 Homebrew PoC는 별도 tap 저장소의 npm package wrapper를 1순위로 둔다. 이 접근은 macOS 설치 UX를 개선하면서도 canonical 기준을 formula 내부로 옮기지 않는다.
 
-Task #34에서 `v0.2.0` npm tarball SHA256과 local Homebrew smoke는 확인됐다. 실제 public 배포는 작업지시자가 public tap 배포를 별도 승인하고, tap 저장소·설치 안내·formula 업데이트 운영 방식을 확정한 뒤에만 진행한다.
+Task #35에서 `postmelee/homebrew-tap` public repository와 `postmelee/tap/hyper-waterfall` 설치 경로가 공개됐고, public tap smoke가 통과했다. Homebrew는 계속 CLI 설치 wrapper이며 canonical 기준은 GitHub Release/tag, `templates/manifest.json`, migration guide다. `brew install hyper-waterfall` 단독 경로는 Homebrew core 등재 검토 결과에 따라 별도 판단한다.

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -120,6 +120,7 @@ v0.2.0 - 배포·업데이트 프로토콜 MVP
 - `docs/agent-entrypoint.md`에 신규 적용과 기존 업데이트 판단 결과 형식을 정리했습니다.
 - npm CLI MVP가 `init`, `update`, `doctor` 판단 결과를 출력하도록 준비되었습니다.
 - 추가 배포 채널은 GitHub Release/tag 기준을 실행하거나 발견하기 쉽게 하는 계층으로 정리했습니다.
+- Homebrew public tap은 `postmelee/tap/hyper-waterfall` 경로로 공개됐고, macOS public tap smoke가 통과했습니다.
 
 ## 업데이트 기준
 
@@ -130,7 +131,8 @@ v0.2.0 - 배포·업데이트 프로토콜 MVP
 ## 보류
 
 - npm publish는 별도 승인 후 `docs/releases/v0.2.0-npm-publish.md` 기준으로 진행합니다.
-- Homebrew, Docker, Codex plugin, Claude plugin 구현은 후속 이슈에서 별도 추적합니다.
+- Docker, Codex plugin, Claude plugin 구현은 후속 이슈에서 별도 추적합니다.
+- `brew install hyper-waterfall` 단독 경로는 Homebrew core 등재가 필요하므로 #46에서 별도 검토합니다.
 - root/directory checksum은 공식 산식 확정 전까지 `pending-release`로 둡니다.
 - 사용자 수정 가능성이 있는 파일은 manifest update policy와 migration guide를 기준으로 수동 확인합니다.
 ```
@@ -148,7 +150,7 @@ gh release create v0.2.0 --title "v0.2.0 - 배포·업데이트 프로토콜 MVP
 ## 보류 항목
 
 - npm publish 실행 (`docs/releases/v0.2.0-npm-publish.md` 기준으로 별도 승인 후 진행)
-- Homebrew formula/tap 구현
+- Homebrew core 등재 검토와 제출 준비 (#46)
 - Docker image 구현
 - Codex plugin과 Claude plugin packaging
 - 자동 release pipeline

--- a/mydocs/orders/20260510.md
+++ b/mydocs/orders/20260510.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #34 | Homebrew formula local tap smoke PoC | 완료 | 완료: 08:36, local tap smoke 검증과 최종 보고서 작성 완료 |
 | #44 | manual 문서 중립성 정책 반영 | 완료 | 완료: 15:29, manual 중립성 정책과 관련 문서 정합성 보강 완료 |
-| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 1 완료, public tap 생성·formula push 승인 대기 |
+| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 2 완료, public tap formula 게시 후 Stage 3 승인 대기 |

--- a/mydocs/orders/20260510.md
+++ b/mydocs/orders/20260510.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #34 | Homebrew formula local tap smoke PoC | 완료 | 완료: 08:36, local tap smoke 검증과 최종 보고서 작성 완료 |
 | #44 | manual 문서 중립성 정책 반영 | 완료 | 완료: 15:29, manual 중립성 정책과 관련 문서 정합성 보강 완료 |
-| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 3 완료, public tap smoke 검증 후 설치 안내 문서 갱신 승인 대기 |
+| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 4 완료, Homebrew 설치 안내 문서 갱신 후 최종 보고 대기 |

--- a/mydocs/orders/20260510.md
+++ b/mydocs/orders/20260510.md
@@ -6,3 +6,4 @@
 |------|--------|------|------|
 | #34 | Homebrew formula local tap smoke PoC | 완료 | 완료: 08:36, local tap smoke 검증과 최종 보고서 작성 완료 |
 | #44 | manual 문서 중립성 정책 반영 | 완료 | 완료: 15:29, manual 중립성 정책과 관련 문서 정합성 보강 완료 |
+| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | M040, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260510.md
+++ b/mydocs/orders/20260510.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #34 | Homebrew formula local tap smoke PoC | 완료 | 완료: 08:36, local tap smoke 검증과 최종 보고서 작성 완료 |
 | #44 | manual 문서 중립성 정책 반영 | 완료 | 완료: 15:29, manual 중립성 정책과 관련 문서 정합성 보강 완료 |
-| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | M040, 수행계획서 작성 후 승인 대기 |
+| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | M040, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260510.md
+++ b/mydocs/orders/20260510.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #34 | Homebrew formula local tap smoke PoC | 완료 | 완료: 08:36, local tap smoke 검증과 최종 보고서 작성 완료 |
 | #44 | manual 문서 중립성 정책 반영 | 완료 | 완료: 15:29, manual 중립성 정책과 관련 문서 정합성 보강 완료 |
-| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 2 완료, public tap formula 게시 후 Stage 3 승인 대기 |
+| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 3 완료, public tap smoke 검증 후 설치 안내 문서 갱신 승인 대기 |

--- a/mydocs/orders/20260510.md
+++ b/mydocs/orders/20260510.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #34 | Homebrew formula local tap smoke PoC | 완료 | 완료: 08:36, local tap smoke 검증과 최종 보고서 작성 완료 |
 | #44 | manual 문서 중립성 정책 반영 | 완료 | 완료: 15:29, manual 중립성 정책과 관련 문서 정합성 보강 완료 |
-| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 4 완료, Homebrew 설치 안내 문서 갱신 후 최종 보고 대기 |
+| #35 | Homebrew public tap 배포와 설치 안내 | 완료 | 완료: 09:31, public tap 배포·smoke·설치 안내·최종 보고서 작성 완료 |

--- a/mydocs/orders/20260510.md
+++ b/mydocs/orders/20260510.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #34 | Homebrew formula local tap smoke PoC | 완료 | 완료: 08:36, local tap smoke 검증과 최종 보고서 작성 완료 |
 | #44 | manual 문서 중립성 정책 반영 | 완료 | 완료: 15:29, manual 중립성 정책과 관련 문서 정합성 보강 완료 |
-| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | M040, 구현계획서 작성 후 승인 대기 |
+| #35 | Homebrew public tap 배포와 설치 안내 | 진행중 | Stage 1 완료, public tap 생성·formula push 승인 대기 |

--- a/mydocs/plans/task_m040_35.md
+++ b/mydocs/plans/task_m040_35.md
@@ -1,0 +1,155 @@
+# Task #35 수행계획서 - Homebrew public tap 배포와 설치 안내
+
+GitHub Issue: [#35](https://github.com/postmelee/hyper-waterfall/issues/35)
+마일스톤: M040
+
+## 목적
+
+Task #34에서 통과한 Homebrew local tap smoke 결과를 public tap 배포 후보로 승격할지 판단하고, 승인된 경우 macOS 사용자가 실제 공개 경로로 `hyper-waterfall@0.2.0` CLI를 설치할 수 있게 한다.
+
+이번 task의 핵심 결과는 승인된 public tap 경로, 공개 formula, 공개 설치 명령의 smoke 결과, 그리고 README 또는 release notes에 반영할 설치 안내다. public tap 배포가 보류되면 보류 사유와 남은 승인 항목을 문서로 고정한다.
+
+## 배경
+
+M040은 Docker를 제외하고 npm, Homebrew, Codex, Claude 채널의 v0.2.0 최종 배포 가능 상태를 만드는 마일스톤이다. #33에서 `hyper-waterfall@0.2.0` npm publish와 post-publish 검증이 끝났고, #34에서 npm tarball wrapper formula의 local tap smoke가 통과했다.
+
+Task #34 산출물 기준 public tap 배포 전 남은 보류 조건은 public tap 저장소 이름과 공개 범위 확정, formula source 보관 위치 결정, README 또는 release notes 설치 안내 승인, Homebrew `node` 의존성 영향 안내, release마다 formula `url`과 `sha256`을 갱신하는 운영 방식 결정이다.
+
+참고 문서:
+
+- `docs/homebrew-formula-tap-poc.md`
+- `mydocs/tech/task_m040_34_homebrew_local_tap_smoke.md`
+- `docs/distribution-channels.md`
+- `docs/releases/v0.2.0.md`
+- `docs/releases/v0.2.0-npm-publish.md`
+
+## 범위
+
+### 포함
+
+- public tap 저장소 이름, 공개 범위, 기본 branch, formula source 위치 결정안 작성
+- 작업지시자 승인 후 public tap repository 생성 또는 기존 repository 확인
+- `hyper-waterfall` formula 게시 또는 배포 보류 사유 문서화
+- 공개 경로 기준 `brew tap`, `brew install --build-from-source`, `hyper-waterfall --version`, `hyper-waterfall doctor --repo .`, `brew test` smoke
+- README, release notes, 배포 채널 문서 중 Homebrew 설치 안내 반영 위치 결정과 갱신
+- Homebrew formula가 canonical 기준이 아니라 npm CLI 설치 wrapper임을 문서에 명시
+- Homebrew `node` 의존성과 `npm`/`npx` link overwrite backup 가능성 안내 여부 판단
+
+### 제외
+
+- formula 자동 갱신 pipeline 구현
+- Docker image 관련 작업
+- Codex/Claude plugin packaging
+- npm package publish 재실행
+- GitHub Release/tag 신규 생성
+- manifest, migration guide, checksum 정책을 formula 내부에 복제하는 작업
+- 작업지시자 승인 전 public tap repository 생성, formula push, README 공개 설치 안내 추가
+
+## 설계 방향
+
+- 기본 후보는 `postmelee/homebrew-tap` repository, install name은 `postmelee/tap/hyper-waterfall`로 둔다. Homebrew tap naming 관례상 GitHub repository 이름은 `homebrew-` 접두를 포함하고, 사용자 명령에서는 `postmelee/tap`으로 축약된다.
+- formula는 Task #34에서 검증한 npm tarball wrapper를 재사용한다. URL은 `https://registry.npmjs.org/hyper-waterfall/-/hyper-waterfall-0.2.0.tgz`, SHA256은 `34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7`을 사용한다.
+- public tap repository는 외부 공개 산출물이므로 Stage 1에서 승인 항목을 고정한 뒤에만 생성하거나 push한다.
+- 설치 안내는 canonical 기준을 흐리지 않도록 "Homebrew는 macOS CLI 설치 wrapper"로 표현한다. version 기준은 GitHub Release/tag, `templates/manifest.json`, migration guide가 계속 담당한다.
+- Homebrew `node` 의존성이 기존 `/opt/homebrew/bin/npm`, `/opt/homebrew/bin/npx` link 상태에 영향을 줄 수 있음을 troubleshooting 또는 주의 문구로 남길지 검토한다.
+- smoke가 실패하거나 public tap 공개 승인이 보류되면 외부 변경을 되돌리기보다 보류 사유, 실패 명령, 다음 승인 항목을 보고서에 남긴다.
+
+## 예상 변경 파일
+
+신규:
+
+- `mydocs/plans/task_m040_35.md`
+- `mydocs/plans/task_m040_35_impl.md`
+- `mydocs/working/task_m040_35_stage1.md`
+- `mydocs/working/task_m040_35_stage2.md`
+- `mydocs/working/task_m040_35_stage3.md`
+- `mydocs/working/task_m040_35_stage4.md`
+- `mydocs/report/task_m040_35_report.md`
+- `mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md`
+
+수정:
+
+- `mydocs/orders/20260510.md`
+- `docs/homebrew-formula-tap-poc.md`
+- `docs/distribution-channels.md`
+- `README.md` 또는 `docs/releases/v0.2.0.md`
+- 필요 시 `docs/releases/v0.2.0-npm-publish.md`
+
+외부 산출물 후보:
+
+- `postmelee/homebrew-tap` GitHub repository
+- `postmelee/homebrew-tap`의 `Formula/hyper-waterfall.rb`
+- 필요 시 tap repository `README.md`
+
+이번 task 산출물:
+
+- `mydocs/orders/20260510.md`
+- `mydocs/plans/task_m040_35.md`
+- `mydocs/plans/task_m040_35_impl.md`
+- `mydocs/working/task_m040_35_stage{N}.md`
+- `mydocs/report/task_m040_35_report.md`
+
+## 잠정 단계
+
+- **Stage 1 — public tap 배포 승인 조건 확정**
+  - 산출물: tap 이름, 공개 범위, branch, formula source 위치, README/release notes 반영 범위, 외부 작업 승인 항목 정리
+  - 검증 관점: #34 인계 항목과 #35 issue 수용 기준이 빠짐없이 반영됐는지 확인
+- **Stage 2 — public tap formula 게시 또는 보류 기록**
+  - 산출물: 승인 시 public tap repository와 formula 게시, 보류 시 명확한 보류 사유와 다음 조치 기록
+  - 검증 관점: Homebrew tap naming, formula syntax, URL/SHA256/license/node dependency/std_npm_args/test block 확인
+- **Stage 3 — 공개 설치 경로 smoke 검증**
+  - 산출물: `mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md`, Stage 3 보고서
+  - 검증 관점: `brew tap`, `brew install --build-from-source`, `--version`, `doctor --repo .`, `brew test`, cleanup/read-only 확인
+- **Stage 4 — 설치 안내와 배포 문서 갱신**
+  - 산출물: README 또는 release notes 설치 안내, `docs/homebrew-formula-tap-poc.md`, `docs/distribution-channels.md` 갱신
+  - 검증 관점: Homebrew가 canonical 기준이 아닌 wrapper로 설명되는지, public tap 설치 명령과 보류/후속 항목이 일관되는지 확인
+
+## 검증 계획
+
+### 단계별 검증
+
+- Stage 1
+  - `rg -n 'public tap|homebrew-tap|postmelee/tap|Homebrew|node|README|release notes|보류|승인' docs mydocs`
+  - 승인 항목이 외부 공개 작업과 문서 반영 작업을 분리하는지 수동 확인
+- Stage 2
+  - `ruby -c Formula/hyper-waterfall.rb`
+  - `rg -n 'class HyperWaterfall|url "|sha256 "|depends_on "node"|std_npm_args|bin.install_symlink|test do|doctor --repo' Formula/hyper-waterfall.rb`
+  - `gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url` 또는 보류 사유 확인
+- Stage 3
+  - `brew tap postmelee/tap`
+  - `brew audit --new --formula postmelee/tap/hyper-waterfall`
+  - `brew install --build-from-source postmelee/tap/hyper-waterfall`
+  - `hyper-waterfall --version`
+  - `hyper-waterfall doctor --repo .`
+  - `brew test postmelee/tap/hyper-waterfall`
+  - `git status --short` 실행 전후 비교
+- Stage 4
+  - `rg -n 'brew install|postmelee/tap/hyper-waterfall|Homebrew|canonical|wrapper|node' README.md docs`
+  - `rg -n 'manifest|migration|checksum'`로 formula 문서가 canonical 기준을 대체하지 않는지 수동 확인
+
+### 통합 검증
+
+- 승인된 public tap 경로가 존재하거나, 배포 보류 사유가 명확히 기록된다.
+- 공개 설치 명령이 실제로 동작하거나, 실패/보류 사유와 다음 조치가 기록된다.
+- 설치된 `hyper-waterfall --version`이 `0.2.0`을 출력한다.
+- `hyper-waterfall doctor --repo .`가 read-only로 실행된다.
+- README 또는 release notes의 Homebrew 안내가 canonical 기준이 아닌 설치 wrapper로 설명된다.
+- `git status --short`가 PR 준비 전 빈 출력이다.
+- `git diff --check`가 경고 없이 통과한다.
+
+## 리스크
+
+- **외부 공개 작업의 되돌림 비용**: public GitHub repository 생성과 formula push는 외부에 노출된다. Stage 1 승인 전에는 실행하지 않고, 승인 후에도 변경 내역과 rollback 방법을 기록한다.
+- **Homebrew tap naming 혼동**: repository는 `homebrew-tap`이지만 사용자 명령은 `postmelee/tap`이다. 문서에서 두 이름의 관계를 명확히 설명한다.
+- **Homebrew node 의존성 영향**: `depends_on "node"`가 Homebrew `node`, `npm`, `npx` link 상태에 영향을 줄 수 있다. #34에서 본 warning을 문서 안내 후보로 포함한다.
+- **canonical 기준 drift**: Homebrew formula의 version/SHA256이 manifest checksum이나 migration guide 기준처럼 오해될 수 있다. 설치 wrapper 책임 경계를 반복해서 명시한다.
+- **검증 환경 제한**: public tap smoke는 현재 macOS/Homebrew 환경 기준이다. 실패 시 Homebrew 버전과 환경 차이를 보고서에 남긴다.
+
+## 승인 요청 사항
+
+- 수행계획서의 Stage 1-4 흐름에 동의?
+- public tap 기본 후보를 `postmelee/homebrew-tap` / `postmelee/tap/hyper-waterfall`로 두고 Stage 1에서 최종 승인 항목으로 고정하는 데 동의?
+- Stage 1 승인 전에는 GitHub repository 생성, public tap push, README 공개 설치 안내 추가를 하지 않는 데 동의?
+- README와 release notes 중 어느 문서에 설치 안내를 반영할지는 Stage 1에서 근거를 정리한 뒤 승인받는 방식에 동의?
+
+승인되면 `task_m040_35_impl.md`에서 단계별 산출물, 검증 명령, 커밋 메시지를 구체화한다.

--- a/mydocs/plans/task_m040_35_impl.md
+++ b/mydocs/plans/task_m040_35_impl.md
@@ -1,0 +1,247 @@
+# Task #35 구현계획서 - Homebrew public tap 배포와 설치 안내
+
+수행계획서: [`task_m040_35.md`](task_m040_35.md)
+GitHub Issue: [#35](https://github.com/postmelee/hyper-waterfall/issues/35)
+마일스톤: M040
+
+## 단계 개요
+
+| Stage | 제목 | 주요 산출 | 검증 |
+|---|---|---|---|
+| 1 | public tap 배포 승인 조건 확정 | `mydocs/working/task_m040_35_stage1.md` | #34 인계 항목, #35 수용 기준, public tap 승인 항목 점검 |
+| 2 | public tap formula 게시 또는 보류 기록 | `mydocs/working/task_m040_35_stage2.md`, 외부 tap repository 후보 | `gh repo view`, formula syntax, URL/SHA256/test block 확인 |
+| 3 | 공개 설치 경로 smoke 검증 | `mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md`, `mydocs/working/task_m040_35_stage3.md` | `brew tap/install/version/doctor/test`, read-only, cleanup |
+| 4 | 설치 안내와 배포 문서 갱신 | `docs/homebrew-formula-tap-poc.md`, `docs/distribution-channels.md`, `README.md` 또는 release notes, `mydocs/working/task_m040_35_stage4.md` | 설치 안내 grep, canonical wrapper 경계 확인 |
+
+## Stage 1 — public tap 배포 승인 조건 확정
+
+### 산출물
+
+신규:
+
+- `mydocs/working/task_m040_35_stage1.md`
+
+수정:
+
+- `mydocs/orders/20260510.md`
+
+### 변경 내용
+
+- #34 local tap smoke 결과에서 #35로 넘긴 항목을 다시 정리한다.
+- public tap 기본 후보를 `postmelee/homebrew-tap`, 사용자 설치 이름을 `postmelee/tap/hyper-waterfall`, 기본 branch 후보를 `main`, 공개 범위를 `public`으로 둔다.
+- formula source 위치를 public tap repository의 `Formula/hyper-waterfall.rb`로 두고, 본 저장소에는 공식 formula copy를 두지 않는 방향을 1차 후보로 둔다.
+- README 또는 release notes 설치 안내 반영 범위를 비교한다. 기본 후보는 README에 짧은 설치 경로를 두고, release notes에는 v0.2.0 배포 채널 상태를 갱신하는 방식이다.
+- Stage 2에서 실제로 허용되는 외부 작업을 승인 항목으로 분리한다:
+  - GitHub repository `postmelee/homebrew-tap` 생성 또는 기존 repo 사용
+  - `Formula/hyper-waterfall.rb` commit/push
+  - public tap smoke 실행
+  - README/release notes 공개 설치 안내 반영
+
+### 검증
+
+```bash
+rg -n 'public tap|homebrew-tap|postmelee/tap|Homebrew|node|README|release notes|보류|승인' docs mydocs
+rg -n '34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7|hyper-waterfall@0.2.0|brew test|doctor --repo' docs/homebrew-formula-tap-poc.md mydocs/tech/task_m040_34_homebrew_local_tap_smoke.md mydocs/plans/task_m040_35.md
+git diff --check
+```
+
+수동 확인:
+
+- Stage 1 보고서가 외부 공개 작업 승인 항목과 repo 내부 문서 작업 승인 항목을 분리했는지 확인한다.
+- #35 수용 기준 중 "public tap 경로 존재 또는 보류 사유 기록"이 Stage 2의 분기 조건으로 반영됐는지 확인한다.
+
+### 커밋
+
+```text
+Task #35 Stage 1: Homebrew public tap 승인 조건 정리
+```
+
+## Stage 2 — public tap formula 게시 또는 보류 기록
+
+### 산출물
+
+신규:
+
+- `mydocs/working/task_m040_35_stage2.md`
+- 승인 시 외부 repository `postmelee/homebrew-tap`
+- 승인 시 외부 repository `postmelee/homebrew-tap/Formula/hyper-waterfall.rb`
+
+수정:
+
+- `mydocs/orders/20260510.md`
+
+### 변경 내용
+
+- Stage 1 승인 결과에 따라 `postmelee/homebrew-tap` repository 존재 여부를 확인한다.
+- repository가 없고 작업지시자가 public repo 생성을 명시 승인한 경우에만 `gh repo create postmelee/homebrew-tap --public` 흐름을 수행한다.
+- repository가 있으면 visibility, default branch, clone URL을 확인한다.
+- Task #34 formula 후보를 public tap repository의 `Formula/hyper-waterfall.rb`로 옮긴다.
+- formula는 다음 값을 사용한다:
+  - `url "https://registry.npmjs.org/hyper-waterfall/-/hyper-waterfall-0.2.0.tgz"`
+  - `sha256 "34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7"`
+  - `depends_on "node"`
+  - `system "npm", "install", *std_npm_args`
+  - `bin.install_symlink libexec.glob("bin/*")`
+  - `test do`에서 `--version`과 `doctor --repo #{testpath}` 실행
+- public tap 생성 또는 push가 승인되지 않으면 Stage 2 보고서에 보류 사유와 다음 승인 항목을 기록하고 Stage 3 public smoke로 넘어가지 않는다.
+
+### 검증
+
+승인된 public tap repository가 있는 경우:
+
+```bash
+gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url
+ruby -c /private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap/Formula/hyper-waterfall.rb
+rg -n 'class HyperWaterfall|url "|sha256 "|depends_on "node"|std_npm_args|bin.install_symlink|test do|doctor --repo' /private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap/Formula/hyper-waterfall.rb
+git -C /private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap status --short --branch
+git diff --check
+```
+
+보류된 경우:
+
+```bash
+rg -n '보류|승인|public tap|homebrew-tap|Formula/hyper-waterfall.rb' mydocs/working/task_m040_35_stage2.md
+git diff --check
+```
+
+수동 확인:
+
+- formula가 manifest, migration guide, checksum 정책을 복제하지 않는지 확인한다.
+- 외부 tap repository commit/push 여부와 commit SHA를 Stage 2 보고서에 기록한다.
+
+### 커밋
+
+```text
+Task #35 Stage 2: Homebrew public tap formula 게시 준비
+```
+
+## Stage 3 — 공개 설치 경로 smoke 검증
+
+### 산출물
+
+신규:
+
+- `mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md`
+- `mydocs/working/task_m040_35_stage3.md`
+
+수정:
+
+- `mydocs/orders/20260510.md`
+
+### 변경 내용
+
+- public tap이 실제로 존재하고 formula가 push된 경우에만 공개 경로 smoke를 실행한다.
+- smoke 전후 `git status --short`를 비교해 `hyper-waterfall doctor --repo .`가 repository 파일을 수정하지 않았는지 확인한다.
+- Homebrew install 중 `node`, `npm`, `npx` link 관련 warning이 나오면 그대로 기록한다.
+- 검증 후 `brew uninstall hyper-waterfall`, `brew untap postmelee/tap`, 필요 시 `brew autoremove --dry-run`으로 cleanup 상태를 확인한다.
+- public tap이 보류된 경우 이 Stage는 실행하지 않고 구현계획서 변경 또는 작업지시자 승인 대기로 되돌린다.
+
+### 검증
+
+```bash
+brew tap postmelee/tap
+brew audit --new --formula postmelee/tap/hyper-waterfall
+brew install --build-from-source postmelee/tap/hyper-waterfall
+brew list --versions hyper-waterfall
+which hyper-waterfall
+hyper-waterfall --version
+git status --short
+hyper-waterfall doctor --repo .
+git status --short
+brew test postmelee/tap/hyper-waterfall
+brew uninstall hyper-waterfall
+brew untap postmelee/tap
+brew autoremove --dry-run
+git diff --check
+```
+
+### 커밋
+
+```text
+Task #35 Stage 3: Homebrew public tap smoke 검증
+```
+
+## Stage 4 — 설치 안내와 배포 문서 갱신
+
+### 산출물
+
+신규:
+
+- `mydocs/working/task_m040_35_stage4.md`
+
+수정:
+
+- `docs/homebrew-formula-tap-poc.md`
+- `docs/distribution-channels.md`
+- `README.md` 또는 `docs/releases/v0.2.0.md`
+- 필요 시 `docs/releases/v0.2.0-npm-publish.md`
+- `mydocs/orders/20260510.md`
+
+### 변경 내용
+
+- public tap smoke가 통과하면 README 또는 release notes에 Homebrew 설치 안내를 반영한다.
+- 설치 안내는 최소 명령을 중심으로 둔다:
+  - `brew tap postmelee/tap`
+  - `brew install postmelee/tap/hyper-waterfall`
+  - `hyper-waterfall --version`
+  - `hyper-waterfall doctor --repo .`
+- Homebrew가 canonical 기준이 아닌 macOS CLI 설치 wrapper임을 명시한다.
+- Homebrew `node` dependency와 link warning 가능성은 필요하면 troubleshooting/주의 문구로 반영한다.
+- `docs/homebrew-formula-tap-poc.md`의 승인 게이트를 실제 Stage 2/3 결과에 맞춰 갱신한다.
+- `docs/distribution-channels.md`의 Homebrew 상태를 PoC 후보에서 public tap 공개 또는 보류 상태로 갱신한다.
+- public tap이 보류된 경우 README 공개 설치 안내는 추가하지 않고 보류 상태 문서만 갱신한다.
+
+### 검증
+
+```bash
+rg -n 'brew tap postmelee/tap|brew install postmelee/tap/hyper-waterfall|hyper-waterfall --version|doctor --repo|Homebrew|canonical|wrapper|node' README.md docs
+rg -n 'public tap|homebrew-tap|postmelee/tap|보류|승인|readiness' docs mydocs/tech mydocs/working mydocs/orders/20260510.md
+rg -n 'manifest|migration|checksum' docs/homebrew-formula-tap-poc.md docs/distribution-channels.md README.md docs/releases/v0.2.0.md
+git diff --check
+```
+
+수동 확인:
+
+- README/release notes가 Homebrew를 canonical 배포 기준으로 설명하지 않는지 확인한다.
+- public tap 실제 상태와 문서 상태가 어긋나지 않는지 확인한다.
+
+### 커밋
+
+```text
+Task #35 Stage 4: Homebrew 설치 안내 문서 갱신
+```
+
+## 검증
+
+- 각 Stage 검증 명령은 단계 보고서 작성 전에 실행한다.
+- 실패한 검증은 단계 완료로 처리하지 않는다.
+- 계획 변경이 필요하면 구현계획서를 먼저 갱신하고 작업지시자 승인을 받는다.
+- public tap repository 생성, formula push, 공개 설치 안내 추가는 Stage 1 보고서 승인과 작업지시자 명시 승인 후에만 수행한다.
+
+## 커밋
+
+- 단계 커밋은 단계 산출물과 `mydocs/working/task_m040_35_stage{N}.md`를 함께 묶는다.
+- 커밋 메시지는 `Task #35 Stage {N}: {핵심 내용 요약}` 형식을 따른다.
+- 외부 tap repository에 commit/push가 발생하면 외부 commit SHA와 URL을 Stage 보고서와 최종 보고서에 기록한다.
+
+## 단계 의존성
+
+- Stage 2는 Stage 1 산출물 승인 후 진행한다.
+- Stage 2에서 public tap 생성 또는 formula push가 보류되면 Stage 3으로 넘어가지 않고 보류 사유 보고 후 작업지시자 승인을 다시 받는다.
+- Stage 3은 public tap formula가 공개 경로에 존재한 뒤 진행한다.
+- Stage 4는 Stage 3 smoke 성공 또는 명시적 보류 판단이 기록된 뒤 진행한다.
+
+## 위험과 대응
+
+- **외부 repo 생성/삭제 비용**: public tap repository는 외부에 노출된다. 생성 전 승인 문구를 분리하고, 생성 후 URL과 rollback 후보를 기록한다.
+- **설치 명령 drift**: repository 이름은 `homebrew-tap`이지만 사용자 명령은 `postmelee/tap`이다. 문서에는 두 이름의 관계와 fully qualified formula 이름을 함께 둔다.
+- **Homebrew node link warning**: #34에서 `npm`/`npx` link backup warning이 있었다. Stage 3에서 재현 여부를 기록하고 Stage 4 문서에 안내 반영 여부를 결정한다.
+- **public smoke 실패**: 실패 명령, stderr 핵심, cleanup 결과를 남기고 formula 또는 문서 보정 전 작업지시자 승인을 받는다.
+- **canonical 기준 혼동**: formula URL/SHA256은 CLI artifact 설치 기준이고 manifest checksum이 아니다. Stage 4 문서 검토에서 이 경계를 확인한다.
+
+## 승인 요청 사항
+
+- Stage 1-4 분할, 산출물, 검증 명령, 커밋 메시지에 동의?
+- Stage 1 승인 전에는 외부 public tap repository 생성이나 formula push를 하지 않는 데 동의?
+- Stage 2에서 별도 승인이 내려질 경우 `postmelee/homebrew-tap` public repository와 `postmelee/tap/hyper-waterfall` 설치 이름을 기본값으로 진행하는 데 동의?
+- Stage 3 public smoke가 성공한 뒤 README 또는 release notes 중 실제 반영 위치를 Stage 4에서 확정하는 데 동의?

--- a/mydocs/report/task_m040_35_report.md
+++ b/mydocs/report/task_m040_35_report.md
@@ -1,0 +1,101 @@
+# Task #35 최종 보고서 - Homebrew public tap 배포와 설치 안내
+
+GitHub Issue: [#35](https://github.com/postmelee/hyper-waterfall/issues/35)
+마일스톤: M040
+
+## 작업 요약
+
+- 대상 이슈: #35
+- 마일스톤: M040
+- 단계 수: 4
+- 작업 목적: Task #34 local tap smoke 결과를 public tap 배포로 승격하고, macOS 사용자가 `hyper-waterfall@0.2.0`을 Homebrew public tap으로 설치할 수 있음을 검증해 사용자 문서에 반영한다.
+
+## 변경 파일 목록과 영향 범위
+
+| 경로 | 변경 요약 | 영향 범위 |
+|---|---|---|
+| `mydocs/orders/20260510.md` | #35 상태를 진행중에서 완료로 변경 | 작업 추적 문서 |
+| `mydocs/plans/task_m040_35.md` | 수행계획서 작성 | 작업 범위와 승인 기준 |
+| `mydocs/plans/task_m040_35_impl.md` | Stage 1-4 구현계획서 작성 | 단계별 실행 계획과 검증 명령 |
+| `mydocs/working/task_m040_35_stage1.md` | public tap 배포 전 승인 조건과 기본 후보 정리 | 단계 보고서 |
+| `mydocs/working/task_m040_35_stage2.md` | public tap repository 생성과 formula push 결과 기록 | 단계 보고서 |
+| `mydocs/working/task_m040_35_stage3.md` | public tap install, version, doctor, brew test, cleanup smoke 결과 기록 | 단계 보고서 |
+| `mydocs/working/task_m040_35_stage4.md` | README/docs 설치 안내 갱신과 #46 후속 이슈 등록 결과 기록 | 단계 보고서 |
+| `mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md` | public tap smoke의 명령별 결과, 환경 영향, readiness 기록 | 기술 기록 |
+| `README.md` | macOS Homebrew public tap 설치 명령과 wrapper/canonical 경계 추가 | 사용자-facing 설치 안내 |
+| `docs/homebrew-formula-tap-poc.md` | public tap 승인 게이트를 Task #35 결과 기준으로 갱신 | Homebrew PoC 설계 문서 |
+| `docs/distribution-channels.md` | Homebrew 상태를 public tap smoke 통과 상태로 갱신하고 core 등재를 #46으로 분리 | 배포 채널 전략 문서 |
+| `docs/releases/v0.2.0.md` | release notes 후보에 Homebrew public tap 공개 상태와 core 등재 후속 검토 반영 | v0.2.0 release 준비 문서 |
+| `mydocs/report/task_m040_35_report.md` | 최종 결과보고서 작성 | PR 전 장기 보관 보고 |
+
+외부 산출물:
+
+- public tap repository: `https://github.com/postmelee/homebrew-tap`
+- public tap formula commit: `78ca46a54fa34b4251650607264b3fde132cfdfd Task #35: Add hyper-waterfall formula`
+- formula path: `Formula/hyper-waterfall.rb`
+- install name: `postmelee/tap/hyper-waterfall`
+- 후속 이슈: [#46 Homebrew core 등재 가능성 평가와 제출 준비](https://github.com/postmelee/hyper-waterfall/issues/46)
+
+## 변경 전·후 정량 비교
+
+| 지표 | 변경 전 | 변경 후 |
+|---|---|---|
+| public tap repository | 없음 | `postmelee/homebrew-tap` public repository 생성 |
+| formula source | Task #34 local tap 후보만 존재 | public tap `Formula/hyper-waterfall.rb` 게시 |
+| formula commit | 없음 | `78ca46a54fa34b4251650607264b3fde132cfdfd` |
+| public install smoke | 미수행 | `brew install --build-from-source postmelee/tap/hyper-waterfall` 통과 |
+| CLI version smoke | 미수행 | `hyper-waterfall --version` -> `0.2.0` |
+| `doctor` read-only smoke | 미수행 | `hyper-waterfall doctor --repo .` exit 0, 실행 전후 `git status --short` 빈 출력 |
+| `brew test` | 미수행 | `brew test postmelee/tap/hyper-waterfall` 통과 |
+| 사용자 설치 안내 | README에 Homebrew public tap 설치 안내 없음 | `brew install postmelee/tap/hyper-waterfall` 안내 추가 |
+| `brew install hyper-waterfall` 단독 경로 | 미정 | Homebrew core 등재 필요 항목으로 #46에 분리 |
+| 문서 변경량 | 없음 | 최종 보고 전 기준 12개 파일, 979 insertions, 21 deletions. 이후 최종 보고서와 오늘할일 완료 처리 추가 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 |
+|---|---|
+| 승인된 public tap 경로가 존재하거나, 배포 보류 사유가 명확히 기록된다. | OK — `postmelee/homebrew-tap` public repository를 생성했고, `postmelee/tap/hyper-waterfall` 설치 이름을 smoke와 문서에 고정했다. |
+| 공개 설치 명령이 실제로 동작한다. | OK — Stage 3에서 `brew tap postmelee/tap`, `brew install --build-from-source postmelee/tap/hyper-waterfall`, `brew test postmelee/tap/hyper-waterfall`이 통과했다. |
+| 설치된 `hyper-waterfall --version`이 `0.2.0`을 출력한다. | OK — Stage 3에서 `/opt/homebrew/bin/hyper-waterfall` 기준 `0.2.0`을 확인했다. |
+| `hyper-waterfall doctor --repo .`가 read-only로 실행된다. | OK — Stage 3에서 exit 0, 실행 전후 `git status --short` 빈 출력으로 자동 수정 없음 확인. |
+| 문서가 Homebrew를 canonical 기준이 아닌 설치 wrapper로 설명한다. | OK — README, `docs/homebrew-formula-tap-poc.md`, `docs/distribution-channels.md`, `docs/releases/v0.2.0.md`에 wrapper/canonical 경계를 반영했다. |
+| `brew install hyper-waterfall` 단독 경로의 처리 방향이 명확하다. | OK — Homebrew core 등재가 필요한 후속 범위로 #46을 등록하고 현재 지원 경로와 분리했다. |
+| `git diff --check`가 경고 없이 통과한다. | OK — Stage 1-4와 최종 보고 전 통합 검증에서 통과했다. |
+
+### 단계별 검증 결과
+
+- Stage 1: [`task_m040_35_stage1.md`](../working/task_m040_35_stage1.md) — #34 인계 항목, public tap 기본 후보, 외부 공개 작업 승인 조건, README/release notes 반영 후보 확인. `postmelee/homebrew-tap`이 당시 존재하지 않음을 확인.
+- Stage 2: [`task_m040_35_stage2.md`](../working/task_m040_35_stage2.md) — `postmelee/homebrew-tap` public repository 생성, formula syntax OK, URL/SHA256/Node dependency/std_npm_args/test block 확인, 외부 tap clone clean.
+- Stage 3: [`task_m040_35_stage3.md`](../working/task_m040_35_stage3.md), [`task_m040_35_homebrew_public_tap_smoke.md`](../tech/task_m040_35_homebrew_public_tap_smoke.md) — public tap install, version, doctor read-only, `brew test`, uninstall/untap/autoremove cleanup 통과.
+- Stage 4: [`task_m040_35_stage4.md`](../working/task_m040_35_stage4.md) — README/docs 설치 안내 갱신, wrapper/canonical 경계 확인, #46 후속 이슈 등록.
+
+통합 검증:
+
+- `git fetch origin main` -> `origin/main` 최신화, `HEAD..origin/main` 추가 commit 없음.
+- `ls mydocs/plans/task_m040_35.md ... mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md` -> 계획서, 구현계획서, Stage 1-4 보고서, 기술 기록 존재 확인.
+- `gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url,pushedAt` -> `postmelee/homebrew-tap`, `PUBLIC`, default branch `main`, pushedAt `2026-05-10T06:29:35Z`.
+- `gh issue view 46 --json title,url,state,milestone,labels` -> #46 OPEN, M040, `enhancement`, `infrastructure` 확인.
+- `rg -n 'brew install postmelee/tap/hyper-waterfall|hyper-waterfall --version|hyper-waterfall doctor --repo|Homebrew public tap|Homebrew core|#46|canonical|wrapper|node' README.md docs mydocs/working/task_m040_35_stage4.md mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md` -> 설치 안내, core 후속 이슈, wrapper/canonical 경계, Node runtime 안내 확인.
+- `rg -n '78ca46a54fa34b4251650607264b3fde132cfdfd|34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7|brew audit --new --formula|brew install --build-from-source|brew test|read-only|git status --short' ...` -> formula commit, SHA256, public smoke 근거 확인.
+- `git diff --check` -> 통과.
+- `git status --short --branch` -> 최종 보고서 작성 전 기준 작업트리 clean, `local/task35...origin/main [ahead 6]`.
+
+## 잔여 위험과 후속 작업
+
+### 잔여 위험
+
+- `brew install hyper-waterfall` 단독 첫 설치는 아직 지원하지 않는다. 이 경로는 #46에서 Homebrew core 등재 가능성을 평가해야 한다.
+- release마다 formula `url`과 `sha256`을 갱신하는 운영 방식은 아직 자동화하지 않았다.
+- Homebrew `node` dependency는 사용자 환경에 따라 `npm`/`npx` link warning을 낼 수 있다. Task #35 public smoke에서는 재현되지 않았지만 troubleshooting 문서 후보로 남긴다.
+- public tap repository와 formula는 외부 공개 산출물이다. 문제가 발견되면 삭제나 force push가 아니라 별도 commit/PR로 보정해야 한다.
+
+### 후속 작업 후보
+
+- [#46 Homebrew core 등재 가능성 평가와 제출 준비](https://github.com/postmelee/hyper-waterfall/issues/46)
+- release마다 Homebrew formula `url`과 `sha256`을 갱신하는 수동 checklist 또는 자동화 이슈 등록
+- Homebrew `node` dependency와 link warning troubleshooting 문서화 여부 검토
+
+## 작업지시자 승인 요청
+
+- 최종 보고서, public tap smoke 결과, README/docs 설치 안내, #46 후속 이슈 분리를 승인하면 PR 리뷰와 merge 승인 단계로 진행한다.

--- a/mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md
+++ b/mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md
@@ -1,0 +1,113 @@
+# Homebrew public tap smoke 결과
+
+이 문서는 Task #35에서 public tap `postmelee/tap` 경로로 `hyper-waterfall@0.2.0` formula를 검증한 결과를 기록한다. public tap repository와 formula는 Stage 2에서 게시했고, README/release notes 설치 안내 갱신은 Stage 4 범위다.
+
+## 검증 기준
+
+| 항목 | 값 |
+|---|---|
+| tap repository | `https://github.com/postmelee/homebrew-tap` |
+| tap repository commit | `78ca46a54fa34b4251650607264b3fde132cfdfd` |
+| formula path | `Formula/hyper-waterfall.rb` |
+| install name | `postmelee/tap/hyper-waterfall` |
+| npm package | `hyper-waterfall@0.2.0` |
+| tarball URL | `https://registry.npmjs.org/hyper-waterfall/-/hyper-waterfall-0.2.0.tgz` |
+| SHA256 | `34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7` |
+| 검증 환경 | macOS `26.3.1-arm64`, Homebrew `5.1.10-52-g1c3a79e` |
+
+## formula
+
+게시된 formula:
+
+- `https://github.com/postmelee/homebrew-tap/blob/78ca46a54fa34b4251650607264b3fde132cfdfd/Formula/hyper-waterfall.rb`
+
+formula는 npm CLI 설치 wrapper만 담당한다. GitHub Release/tag, `templates/manifest.json`, migration guide, manifest checksum 정책은 formula 안에 복제하지 않는다.
+
+## 검증 결과
+
+| 검증 | 결과 | 메모 |
+|---|---|---|
+| `brew tap postmelee/tap` | OK | `/opt/homebrew/Library/Taps/postmelee/homebrew-tap`에 tap 등록, `Tapped 1 formula (13 files, 5.8KB)` |
+| `brew audit --new --formula postmelee/tap/hyper-waterfall` | OK | 출력 없이 성공 |
+| `brew install --build-from-source postmelee/tap/hyper-waterfall` | OK | `/opt/homebrew/Cellar/hyper-waterfall/0.2.0: 60 files, 352.7KB` |
+| `brew list --versions hyper-waterfall` | OK | `hyper-waterfall 0.2.0` |
+| `which hyper-waterfall` | OK | `/opt/homebrew/bin/hyper-waterfall` |
+| `hyper-waterfall --version` | OK | `0.2.0` |
+| `hyper-waterfall doctor --repo .` | OK | exit 0, 자동 수정 없음 |
+| `brew test postmelee/tap/hyper-waterfall` | OK | `--version`, `doctor --repo` 실행 |
+| cleanup | OK | `brew uninstall hyper-waterfall`, `brew untap postmelee/tap`, `brew autoremove --dry-run` 완료 |
+
+`doctor --repo .`는 task worktree `/private/tmp/hyper-waterfall-task35` 기준으로 실행했다. `.hyper-waterfall/version.json` 누락과 `.gitkeep` target 누락 경고가 있었지만, 이 smoke의 기준은 CLI 실행, bundled manifest 접근, read-only 동작 확인이다. 실행 전후 `git status --short`는 모두 빈 출력이었다.
+
+## 설치 중 환경 영향
+
+`brew install --build-from-source` 중 Homebrew가 `node 26.0.0`과 관련 의존성을 설치했다.
+
+설치 중 새로 설치된 dependency:
+
+- `ada-url`
+- `brotli`
+- `c-ares`
+- `hdrhistogram_c`
+- `libnghttp3`
+- `libngtcp2`
+- `libuv`
+- `llhttp`
+- `simdutf`
+- `merve`
+- `nbytes`
+- `simdjson`
+- `uvwasi`
+- `node`
+
+Task #34 local tap smoke 때 보였던 `/opt/homebrew/bin/npm`, `/opt/homebrew/bin/npx` overwrite backup warning은 이번 public tap install 출력에서는 재현되지 않았다.
+
+cleanup 결과:
+
+- `brew uninstall hyper-waterfall` 완료.
+- Homebrew autoremove가 이번 install에서 새로 설치된 `node 26.0.0`과 dependency 13개를 제거했다.
+- 기존 Homebrew `node 25.9.0_2`, `llhttp 9.3.1`, `merve 1.2.2`, `simdjson 4.6.1`, `libngtcp2 1.22.0`, `simdutf 8.2.0`은 남아 있다고 Homebrew가 안내했다.
+- `brew untap postmelee/tap` 완료.
+- `brew autoremove --dry-run` 출력 없음.
+- cleanup 이후 `brew list --versions hyper-waterfall`은 출력 없이 exit 1.
+- cleanup 이후 `which hyper-waterfall`은 `hyper-waterfall not found`.
+- cleanup 이후 `brew tap` 출력 없음.
+- shell의 active `node`, `npm`은 nvm 경로 기준 `node v24.15.0`, `npm 11.12.1`이다.
+
+## public tap readiness
+
+판단: public tap technical smoke는 통과했다.
+
+충족된 조건:
+
+- `postmelee/homebrew-tap` public repository가 존재한다.
+- `Formula/hyper-waterfall.rb`가 public tap repository `main`에 push됐다.
+- `brew tap postmelee/tap`이 성공했다.
+- `brew audit --new --formula`가 통과했다.
+- `brew install --build-from-source`가 통과했다.
+- `hyper-waterfall --version`이 `0.2.0`을 출력했다.
+- `hyper-waterfall doctor --repo .`가 실행되고 repository 파일을 수정하지 않았다.
+- `brew test`가 통과했다.
+- smoke 후 cleanup을 완료했다.
+
+남은 항목:
+
+- README 또는 release notes에 Homebrew 설치 안내를 반영할 위치를 확정한다.
+- Homebrew가 canonical 기준이 아니라 macOS CLI 설치 wrapper임을 사용자 문서에 명시한다.
+- release마다 formula `url`과 `sha256`을 갱신하는 운영 방식은 후속 checklist 또는 자동화 이슈로 분리한다.
+
+## Stage 4 인계 항목
+
+- 사용자 설치 명령 후보:
+
+```bash
+brew tap postmelee/tap
+brew install postmelee/tap/hyper-waterfall
+hyper-waterfall --version
+hyper-waterfall doctor --repo .
+```
+
+- README에는 Homebrew를 macOS CLI 설치 wrapper로 짧게 소개한다.
+- `docs/homebrew-formula-tap-poc.md`의 public tap 승인 게이트를 public smoke 통과 상태로 갱신한다.
+- `docs/distribution-channels.md`의 Homebrew 상태를 public tap smoke 통과 상태로 갱신한다.
+- `docs/releases/v0.2.0.md` 또는 release notes 후보에는 필요하면 Homebrew 채널 공개 상태를 짧게 반영한다.

--- a/mydocs/working/task_m040_35_stage1.md
+++ b/mydocs/working/task_m040_35_stage1.md
@@ -1,0 +1,128 @@
+# Task #35 Stage 1 보고서 - Homebrew public tap 승인 조건 정리
+
+GitHub Issue: [#35](https://github.com/postmelee/hyper-waterfall/issues/35)
+구현계획서: [`task_m040_35_impl.md`](../plans/task_m040_35_impl.md)
+Stage: 1
+
+## 단계 목적
+
+이번 Stage의 목적은 Task #34 local tap smoke 결과를 public tap 배포 단계로 넘기기 전에, 외부 공개 작업의 승인 조건과 repo 내부 문서 작업의 승인 조건을 분리해 고정하는 것이다.
+
+Stage 1에서는 public tap repository를 만들거나 formula를 push하지 않았다. 다음 Stage에서 수행할 수 있는 외부 작업의 후보, 기본 이름, 검증 조건, 보류 조건만 문서화했다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `mydocs/working/task_m040_35_stage1.md` | public tap 승인 조건, 기본 후보, 외부 작업 승인 항목, 검증 결과 기록 |
+| `mydocs/orders/20260510.md` | #35 상태를 Stage 1 완료와 public tap 생성·formula push 승인 대기로 갱신 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+신규 Stage 보고서 작성과 오늘할일 1행 비고 갱신만 수행했다. 기존 Homebrew PoC 문서, README, release notes, 배포 채널 문서 본문은 Stage 1에서 수정하지 않았다.
+
+## 확인한 기준
+
+Task #34에서 이미 충족된 조건:
+
+- `hyper-waterfall@0.2.0` npm publish와 registry tarball URL 확인
+- npm tarball SHA256 `34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7` 확인
+- local tap formula 후보 syntax와 구조 확인
+- local tap 기준 `brew audit --new --formula`, `brew install --build-from-source`, `hyper-waterfall --version`, `hyper-waterfall doctor --repo .`, `brew test` 통과
+- `doctor --repo .` 실행 전후 repository 파일 변경 없음
+
+Task #34에서 #35로 남긴 보류 조건:
+
+- 작업지시자의 public tap 배포 명시 승인
+- public tap repository 이름, 기본 branch, 공개 범위 확정
+- formula source를 public tap에만 둘지 본 저장소에도 초안/검증 기록을 둘지 결정
+- README 또는 release notes에 Homebrew 설치 안내를 추가할지 승인
+- Homebrew `node` 의존성과 `/opt/homebrew/bin/npm`, `/opt/homebrew/bin/npx` link overwrite backup warning 안내 여부 결정
+- release마다 formula `url`과 `sha256`을 갱신하는 운영 방식 결정
+
+## Stage 2 기본 후보
+
+| 항목 | Stage 2 기본 후보 | 판단 |
+|---|---|---|
+| public tap repository | `postmelee/homebrew-tap` | Homebrew GitHub tap naming 관례에 맞춘다. 사용자 명령에서는 `postmelee/tap`으로 축약된다. |
+| 공개 범위 | `public` | Homebrew public install 경로 검증이 목적이므로 public repository가 필요하다. |
+| 기본 branch | `main` | 본 저장소 기준과 맞춘다. |
+| formula 경로 | `Formula/hyper-waterfall.rb` | Homebrew tap 일반 구조를 따른다. |
+| formula source 보관 | public tap repository를 공식 source로 둔다. 본 저장소에는 공식 copy를 두지 않고 검증 기록만 둔다. | 중복 source drift를 줄인다. |
+| formula 입력 | npm tarball wrapper | Task #34에서 통과한 접근이며 canonical 기준을 formula 내부로 복제하지 않는다. |
+| 설치 이름 | `postmelee/tap/hyper-waterfall` | 문서와 smoke에서 사용할 공개 설치 경로 후보. |
+
+GitHub repository 존재 여부:
+
+- `gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url`
+- 결과: `GraphQL: Could not resolve to a Repository with the name 'postmelee/homebrew-tap'. (repository)`
+- 판단: Stage 2에서 public tap 배포를 승인한다면 repository 생성이 필요하다.
+
+## Stage 2에서 별도 승인해야 할 외부 작업
+
+다음 작업은 외부에 공개되거나 사용자에게 보이는 변경이므로 Stage 2 진입 승인에서 명시적으로 허용되어야 한다.
+
+- GitHub public repository `postmelee/homebrew-tap` 생성
+- tap repository에 `Formula/hyper-waterfall.rb` commit/push
+- public tap 경로에서 `brew tap postmelee/tap`, `brew install postmelee/tap/hyper-waterfall`, `brew test postmelee/tap/hyper-waterfall` smoke 실행
+- public smoke 성공 후 README 또는 release notes에 Homebrew 설치 안내 추가
+
+Stage 2에서 repository 생성이나 formula push가 승인되지 않으면, Stage 2는 배포 보류 보고서 작성으로 종료하고 Stage 3 public smoke로 넘어가지 않는다.
+
+## 문서 반영 후보
+
+| 문서 | Stage 4 후보 반영 |
+|---|---|
+| `README.md` | 사용자-facing 설치 안내를 짧게 추가하는 1차 후보. `npx` 안내 근처에 Homebrew를 macOS 설치 wrapper로 설명한다. |
+| `docs/releases/v0.2.0.md` | v0.2.0 배포 채널 상태를 release notes 후보에 반영할 수 있다. |
+| `docs/homebrew-formula-tap-poc.md` | public tap 승인 게이트와 실제 public smoke 결과를 갱신한다. |
+| `docs/distribution-channels.md` | Homebrew 상태를 PoC 후보에서 public tap 공개 또는 보류 상태로 갱신한다. |
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+rg -n 'public tap|homebrew-tap|postmelee/tap|Homebrew|node|README|release notes|보류|승인' docs mydocs
+rg -n '34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7|hyper-waterfall@0.2.0|brew test|doctor --repo' docs/homebrew-formula-tap-poc.md mydocs/tech/task_m040_34_homebrew_local_tap_smoke.md mydocs/plans/task_m040_35.md
+gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url
+rg -n 'Homebrew|brew|release notes|install|npx|npm' README.md docs/releases/v0.2.0.md docs/releases/v0.2.0-npm-publish.md docs/distribution-channels.md
+git diff --check
+```
+
+결과:
+
+- OK: 첫 번째 `rg`에서 #34 smoke 결과, PoC 문서, distribution channel 문서, #35 계획/구현계획서의 public tap, Homebrew, node, README/release notes, 승인/보류 항목을 확인했다.
+- OK: 두 번째 `rg`에서 Task #34 SHA256, `hyper-waterfall@0.2.0`, `doctor --repo`, `brew test` 근거를 확인했다.
+- OK: `gh repo view postmelee/homebrew-tap ...`는 승인된 네트워크 접근 기준 repository가 없음을 확인했다.
+- OK: README와 release notes 후보 문서에서 현재 npm/npx 안내와 Homebrew wrapper/canonical 경계 문구를 확인했다.
+- OK: `git diff --check`는 경고 없이 통과했다.
+
+수동 확인:
+
+- OK: Stage 1 보고서는 외부 공개 작업 승인 항목과 repo 내부 문서 작업 승인 항목을 분리했다.
+- OK: #35 수용 기준의 "public tap 경로 존재 또는 보류 사유 기록"은 Stage 2의 분기 조건으로 반영되어 있다.
+- OK: Stage 1에서는 public repository 생성, formula push, README 공개 설치 안내 추가를 수행하지 않았다.
+
+## 잔여 위험
+
+- `postmelee/homebrew-tap` repository가 아직 없으므로 Stage 2 승인 시 외부 public repository 생성이 필요하다.
+- public tap 생성과 formula push는 외부에 노출되는 작업이다. Stage 2에서 명시 승인 없이 진행하면 안 된다.
+- Homebrew `node` 의존성은 사용자 환경의 Homebrew `npm`/`npx` link 상태에 영향을 줄 수 있다. Stage 3 smoke와 Stage 4 문서에서 안내 여부를 다시 확인해야 한다.
+- formula 업데이트 자동화는 이번 task 범위가 아니므로 release마다 수동 갱신하거나 후속 이슈로 분리해야 한다.
+
+## 다음 단계 영향
+
+Stage 2는 아래 조건이 승인되어야 진행할 수 있다.
+
+- public repository `postmelee/homebrew-tap` 생성 승인
+- `Formula/hyper-waterfall.rb`를 public tap repository에 commit/push 승인
+- formula 값은 Task #34에서 검증한 npm tarball URL과 SHA256 사용 승인
+- repository 기본 branch `main`, 공개 범위 `public`, 설치 이름 `postmelee/tap/hyper-waterfall` 승인
+
+Stage 2가 완료되어 public tap formula가 공개 경로에 존재해야 Stage 3 public smoke로 넘어갈 수 있다.
+
+## 승인 요청
+
+- Stage 1 산출물과 검증 결과를 승인하면 Stage 2로 진행한다.
+- Stage 2 진행은 다음 외부 공개 작업 승인을 포함한다: `postmelee/homebrew-tap` public repository 생성, `Formula/hyper-waterfall.rb` commit/push, 이후 public tap smoke 준비.

--- a/mydocs/working/task_m040_35_stage2.md
+++ b/mydocs/working/task_m040_35_stage2.md
@@ -1,0 +1,134 @@
+# Task #35 Stage 2 보고서 - Homebrew public tap formula 게시 준비
+
+GitHub Issue: [#35](https://github.com/postmelee/hyper-waterfall/issues/35)
+구현계획서: [`task_m040_35_impl.md`](../plans/task_m040_35_impl.md)
+Stage: 2
+
+## 단계 목적
+
+이번 Stage의 목적은 Stage 1에서 승인 대기 항목으로 분리한 public tap repository 생성과 formula push를 실제 외부 산출물로 반영하는 것이다.
+
+작업지시자의 Stage 2 진행 승인에 따라 `postmelee/homebrew-tap` public repository를 생성하고, Task #34에서 검증한 npm tarball wrapper formula를 `Formula/hyper-waterfall.rb`로 게시했다. 공개 설치 smoke는 아직 실행하지 않았고 Stage 3 범위로 남겼다.
+
+## 산출물
+
+| 파일 또는 외부 산출물 | 변경 요약 |
+|---|---|
+| `mydocs/working/task_m040_35_stage2.md` | public tap repository 생성, formula push, 검증 결과 기록 |
+| `mydocs/orders/20260510.md` | #35 상태를 Stage 2 완료와 Stage 3 승인 대기로 갱신 |
+| `https://github.com/postmelee/homebrew-tap` | public Homebrew tap repository 생성 |
+| `https://github.com/postmelee/homebrew-tap/blob/78ca46a54fa34b4251650607264b3fde132cfdfd/Formula/hyper-waterfall.rb` | `hyper-waterfall@0.2.0` formula 게시 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+본 저장소에서는 신규 Stage 보고서와 오늘할일 1행 비고만 변경했다. 기존 README, release notes, Homebrew PoC 문서, distribution channel 문서는 Stage 2에서 수정하지 않았다.
+
+외부 tap repository에는 신규 formula 파일 1개만 추가했다. formula는 Task #34에서 local tap smoke를 통과한 구조를 유지했고, manifest, migration guide, checksum 정책을 formula 안에 복제하지 않았다.
+
+## 외부 repository 생성 결과
+
+생성 명령:
+
+```bash
+gh repo create postmelee/homebrew-tap --public --description "Homebrew tap for Hyper-Waterfall"
+```
+
+결과:
+
+- repository URL: `https://github.com/postmelee/homebrew-tap`
+- visibility: `PUBLIC`
+- default branch: `main`
+- `gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url,pushedAt` 결과:
+
+```json
+{"defaultBranchRef":{"name":"main"},"nameWithOwner":"postmelee/homebrew-tap","pushedAt":"2026-05-10T06:29:35Z","url":"https://github.com/postmelee/homebrew-tap","visibility":"PUBLIC"}
+```
+
+## formula 게시 결과
+
+외부 tap repository local clone:
+
+- `/private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap`
+
+formula path:
+
+- `Formula/hyper-waterfall.rb`
+
+외부 tap commit:
+
+```text
+78ca46a54fa34b4251650607264b3fde132cfdfd Task #35: Add hyper-waterfall formula
+```
+
+push 결과:
+
+```text
+To https://github.com/postmelee/homebrew-tap.git
+ * [new branch]      main -> main
+```
+
+formula 핵심 값:
+
+```ruby
+url "https://registry.npmjs.org/hyper-waterfall/-/hyper-waterfall-0.2.0.tgz"
+sha256 "34dc90ca4b9cefa3f13034711e6bffc3f3c184360c44ab4924e00e26163e0cc7"
+depends_on "node"
+```
+
+formula install/test 구조:
+
+- `system "npm", "install", *std_npm_args`
+- `bin.install_symlink libexec.glob("bin/*")`
+- `test do`에서 `hyper-waterfall --version`과 `hyper-waterfall doctor --repo #{testpath}` 실행
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url,pushedAt
+ruby -c /private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap/Formula/hyper-waterfall.rb
+rg -n 'class HyperWaterfall|url "|sha256 "|depends_on "node"|std_npm_args|bin.install_symlink|test do|doctor --repo' /private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap/Formula/hyper-waterfall.rb
+rg -n 'manifest|migration|checksum|templates/manifest|version.json' /private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap/Formula/hyper-waterfall.rb
+git -C /private/tmp/hyper-waterfall-task35-homebrew/homebrew-tap status --short --branch
+git diff --check
+```
+
+결과:
+
+- OK: `gh repo view`에서 `postmelee/homebrew-tap`, `PUBLIC`, default branch `main`, URL을 확인했다.
+- OK: `ruby -c` 결과 `Syntax OK`.
+- OK: formula 구조 grep에서 class, tarball URL, SHA256, `depends_on "node"`, `std_npm_args`, `bin.install_symlink`, `test do`, `doctor --repo`를 확인했다.
+- OK: canonical 기준 복제 의심 키워드 grep은 출력 없음. 이 결과는 formula가 manifest, migration, checksum, version 상태 파일 정책을 복제하지 않았음을 확인하기 위한 no-match 검증이다.
+- OK: 외부 tap clone status는 `## main...origin/main`으로 clean.
+- OK: 본 저장소 `git diff --check`는 경고 없이 통과했다.
+
+수동 확인:
+
+- OK: formula는 npm CLI 설치 wrapper이며 GitHub Release/tag, `templates/manifest.json`, migration guide, manifest checksum 정책을 대체하지 않는다.
+- OK: public tap repository에는 formula 파일만 게시했고 README 설치 안내는 아직 추가하지 않았다.
+- OK: public install smoke는 아직 실행하지 않았고 Stage 3 범위로 남겼다.
+
+## 잔여 위험
+
+- public tap repository와 formula는 이미 공개됐다. 문제가 발견되면 formula 수정 PR/commit으로 보정해야 하며, 삭제나 force push는 별도 승인 없이는 수행하지 않는다.
+- `brew tap`, `brew install`, `brew test` 공개 경로 smoke는 아직 실행하지 않았다.
+- Homebrew `node` 의존성으로 인한 `npm`/`npx` link warning 재현 여부는 Stage 3에서 확인해야 한다.
+- public tap README는 아직 없다. README가 필요한지는 Stage 4 문서 안내 작업에서 판단한다.
+
+## 다음 단계 영향
+
+Stage 3은 공개 경로 기준으로 다음 smoke를 실행할 수 있다.
+
+- `brew tap postmelee/tap`
+- `brew audit --new --formula postmelee/tap/hyper-waterfall`
+- `brew install --build-from-source postmelee/tap/hyper-waterfall`
+- `hyper-waterfall --version`
+- `hyper-waterfall doctor --repo .`
+- `brew test postmelee/tap/hyper-waterfall`
+
+Stage 3에서는 smoke 전후 `git status --short`를 비교해 `doctor --repo .` read-only 동작을 다시 확인하고, cleanup 결과까지 기록해야 한다.
+
+## 승인 요청
+
+- Stage 2 산출물과 검증 결과를 승인하면 Stage 3 공개 설치 경로 smoke 검증으로 진행한다.

--- a/mydocs/working/task_m040_35_stage3.md
+++ b/mydocs/working/task_m040_35_stage3.md
@@ -1,0 +1,91 @@
+# Task #35 Stage 3 보고서 - Homebrew public tap smoke 검증
+
+GitHub Issue: [#35](https://github.com/postmelee/hyper-waterfall/issues/35)
+구현계획서: [`task_m040_35_impl.md`](../plans/task_m040_35_impl.md)
+Stage: 3
+
+## 단계 목적
+
+이번 Stage의 목적은 Stage 2에서 게시한 public tap formula를 실제 공개 설치 경로로 검증하는 것이다. `brew tap`, `brew audit`, `brew install`, CLI version, `doctor`, `brew test`, cleanup을 실행해 #35 수용 기준의 공개 설치 경로 동작 여부를 확인했다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md` | public tap smoke 결과, 설치/cleanup 결과, readiness, Stage 4 인계 항목 기록 |
+| `mydocs/working/task_m040_35_stage3.md` | Stage 3 검증 결과와 다음 단계 영향 기록 |
+| `mydocs/orders/20260510.md` | #35 상태를 Stage 3 완료와 설치 안내 문서 갱신 승인 대기로 갱신 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+신규 기술 기록과 신규 Stage 보고서 작성, 오늘할일 1행 비고 갱신만 수행했다. README, release notes, Homebrew PoC 문서, distribution channel 문서는 Stage 3에서 수정하지 않았다.
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+brew tap postmelee/tap
+brew audit --new --formula postmelee/tap/hyper-waterfall
+brew install --build-from-source postmelee/tap/hyper-waterfall
+brew list --versions hyper-waterfall
+which hyper-waterfall
+hyper-waterfall --version
+git status --short
+hyper-waterfall doctor --repo .
+git status --short
+brew test postmelee/tap/hyper-waterfall
+brew uninstall hyper-waterfall
+brew untap postmelee/tap
+brew autoremove --dry-run
+git diff --check
+```
+
+결과:
+
+- OK: `brew tap postmelee/tap` 성공. `/opt/homebrew/Library/Taps/postmelee/homebrew-tap`에 tap 등록, `Tapped 1 formula (13 files, 5.8KB)`.
+- OK: `brew audit --new --formula postmelee/tap/hyper-waterfall` 성공, 출력 없음.
+- OK: `brew install --build-from-source postmelee/tap/hyper-waterfall` 성공. `/opt/homebrew/Cellar/hyper-waterfall/0.2.0: 60 files, 352.7KB`.
+- OK: `brew list --versions hyper-waterfall` -> `hyper-waterfall 0.2.0`.
+- OK: `which hyper-waterfall` -> `/opt/homebrew/bin/hyper-waterfall`.
+- OK: `hyper-waterfall --version` -> `0.2.0`.
+- OK: `hyper-waterfall doctor --repo .` exit 0. `doctor` 출력은 manifest load, frameworkVersion `0.2.0`, read-only safety 문구를 포함했다.
+- OK: `doctor --repo .` 실행 전후 `git status --short`는 모두 빈 출력.
+- OK: `brew test postmelee/tap/hyper-waterfall` 성공. test block에서 `--version`과 `doctor --repo` 실행.
+- OK: cleanup 완료. `brew uninstall hyper-waterfall`, `brew untap postmelee/tap`, `brew autoremove --dry-run` 실행.
+- OK: cleanup 이후 `brew list --versions hyper-waterfall` 출력 없음, `which hyper-waterfall`은 `hyper-waterfall not found`, `brew tap` 출력 없음.
+- OK: `git diff --check`는 경고 없이 통과했다.
+
+## 로컬 환경 영향
+
+`brew install --build-from-source` 중 Homebrew가 `node 26.0.0`과 dependency 13개를 설치했다. uninstall 과정에서 Homebrew autoremove가 이번 install에서 새로 설치된 `node 26.0.0`과 dependency를 제거했다.
+
+기존 Homebrew formula 버전은 유지됐다:
+
+- `node 25.9.0_2`
+- `llhttp 9.3.1`
+- `merve 1.2.2`
+- `simdjson 4.6.1`
+- `libngtcp2 1.22.0`
+- `simdutf 8.2.0`
+
+Task #34 local tap smoke 때 보였던 `/opt/homebrew/bin/npm`, `/opt/homebrew/bin/npx` overwrite backup warning은 이번 public tap install 출력에서는 재현되지 않았다. cleanup 이후 shell의 active `node`, `npm`은 nvm 경로 기준 `node v24.15.0`, `npm 11.12.1`이다.
+
+## 잔여 위험
+
+- public tap repository와 formula는 공개 상태다. 문제가 발견되면 별도 commit/PR로 보정해야 하며 삭제나 force push는 별도 승인 없이 수행하지 않는다.
+- Homebrew `node` dependency는 사용자 환경에 따라 `npm`/`npx` link warning을 낼 수 있다. Stage 4 문서에는 Homebrew가 Node runtime을 설치할 수 있다는 안내를 짧게 남기는 것이 좋다.
+- release마다 formula `url`과 `sha256`을 갱신하는 운영 방식은 이번 task에서 자동화하지 않는다.
+
+## 다음 단계 영향
+
+Stage 4에서는 public tap smoke 통과 상태를 사용자 문서에 반영한다.
+
+- README 또는 release notes에 Homebrew 설치 안내를 추가한다.
+- `docs/homebrew-formula-tap-poc.md`의 public tap 승인 게이트를 public smoke 통과 상태로 갱신한다.
+- `docs/distribution-channels.md`의 Homebrew 상태를 public tap 공개 상태로 갱신한다.
+- Homebrew가 canonical 기준이 아니라 macOS CLI 설치 wrapper임을 명시한다.
+
+## 승인 요청
+
+- Stage 3 산출물과 검증 결과를 승인하면 Stage 4 설치 안내와 배포 문서 갱신으로 진행한다.

--- a/mydocs/working/task_m040_35_stage4.md
+++ b/mydocs/working/task_m040_35_stage4.md
@@ -1,0 +1,79 @@
+# Task #35 Stage 4 보고서 - Homebrew 설치 안내 문서 갱신
+
+GitHub Issue: [#35](https://github.com/postmelee/hyper-waterfall/issues/35)
+구현계획서: [`task_m040_35_impl.md`](../plans/task_m040_35_impl.md)
+Stage: 4
+
+## 단계 목적
+
+이번 Stage의 목적은 Stage 3에서 통과한 public tap smoke 결과를 사용자-facing 문서와 배포 채널 문서에 반영하는 것이다. `brew install postmelee/tap/hyper-waterfall`을 현재 지원되는 한 줄 설치 경로로 안내하고, `brew install hyper-waterfall` 단독 경로는 Homebrew core 등재가 필요하므로 후속 이슈로 분리했다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `README.md` | npm CLI 안내 아래에 Homebrew public tap 설치 명령과 wrapper/canonical 경계를 추가 |
+| `docs/homebrew-formula-tap-poc.md` | public tap 승인 게이트를 Task #35 결과 기준으로 갱신하고 #46 core 등재 검토를 후속 작업으로 연결 |
+| `docs/distribution-channels.md` | Homebrew 상태를 public tap smoke 통과 상태로 갱신하고 core 등재 검토를 #46으로 분리 |
+| `docs/releases/v0.2.0.md` | release notes 후보에 Homebrew public tap 공개 상태와 core 등재 후속 검토를 반영 |
+| `mydocs/orders/20260510.md` | #35 상태를 Stage 4 완료와 최종 보고 대기로 갱신 |
+| `mydocs/working/task_m040_35_stage4.md` | Stage 4 검증 결과와 다음 단계 영향 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+기존 문서 구조와 기존 npm/npx 안내는 유지했다. Homebrew 관련 상태만 public tap smoke 통과 이후 상태로 보강했고, `brew install hyper-waterfall` 단독 경로는 현 지원 경로로 쓰지 않고 #46 후속 이슈로 분리했다.
+
+## 후속 이슈 등록
+
+사용자 요청에 따라 Homebrew core 등재 검토를 후속 이슈로 등록했다.
+
+- [#46 Homebrew core 등재 가능성 평가와 제출 준비](https://github.com/postmelee/hyper-waterfall/issues/46)
+- milestone: M040
+- labels: `enhancement`, `infrastructure`
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+rg -n 'brew tap postmelee/tap|brew install postmelee/tap/hyper-waterfall|hyper-waterfall --version|doctor --repo|Homebrew|canonical|wrapper|node' README.md docs
+rg -n 'public tap|homebrew-tap|postmelee/tap|보류|승인|readiness|#46|Homebrew core' docs mydocs/tech mydocs/working mydocs/orders/20260510.md
+rg -n 'manifest|migration|checksum' docs/homebrew-formula-tap-poc.md docs/distribution-channels.md README.md docs/releases/v0.2.0.md
+git diff --check
+```
+
+결과:
+
+- OK: README와 docs에서 `brew install postmelee/tap/hyper-waterfall`, `hyper-waterfall --version`, `doctor --repo`, Homebrew wrapper/canonical 경계, Node runtime 안내를 확인했다.
+- OK: public tap, `homebrew-tap`, `postmelee/tap`, readiness, #46 Homebrew core 후속 이슈 연결을 확인했다.
+- OK: manifest, migration, checksum 관련 문구는 Homebrew가 canonical 기준을 대체하지 않는다는 맥락으로만 남아 있음을 확인했다.
+- OK: `git diff --check`는 경고 없이 통과했다.
+
+수동 확인:
+
+- OK: README는 `brew install hyper-waterfall` 단독 경로를 현재 지원 경로로 안내하지 않는다.
+- OK: 지원되는 한 줄 설치 경로는 `brew install postmelee/tap/hyper-waterfall`로 명시했다.
+- OK: `brew install hyper-waterfall` 첫 설치 지원은 #46 Homebrew core 등재 검토로 분리했다.
+- OK: public tap 실제 상태와 문서 상태가 일치한다.
+
+## 잔여 위험
+
+- `brew install hyper-waterfall` 단독 첫 설치는 아직 지원하지 않는다. 이 경로는 #46에서 Homebrew core 등재 가능성을 평가한 뒤 별도 결정해야 한다.
+- release마다 formula `url`과 `sha256`을 갱신하는 운영 방식은 아직 자동화하지 않았다.
+- Homebrew `node` dependency는 사용자 환경에 따라 link warning을 낼 수 있으므로, 향후 troubleshooting 문서가 필요할 수 있다.
+
+## 다음 단계 영향
+
+모든 구현 Stage가 끝났다. 다음 단계는 `task-final-report` 절차로 최종 보고서 작성, 오늘할일 완료 처리, PR 게시 준비를 진행한다.
+
+최종 보고서에는 다음을 포함해야 한다.
+
+- public tap repository와 formula commit
+- public tap smoke 통과 결과
+- README/docs 설치 안내 갱신 결과
+- #46 후속 이슈 등록 결과
+- 남은 리스크: Homebrew core 등재와 formula update 운영 방식
+
+## 승인 요청
+
+- Stage 4 산출물과 검증 결과를 승인하면 최종 결과보고서 작성 절차로 진행한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: Closes #35 Homebrew public tap 배포와 설치 안내
- 왜: Task #34 local tap smoke를 실제 macOS 사용자 설치 경로로 승격하고, public tap 공개와 안내 문서 반영을 승인 게이트 안에서 추적하기 위해서입니다.
- 무엇: `postmelee/homebrew-tap` public repository와 formula 게시 결과, public tap smoke, README/docs 설치 안내, #46 Homebrew core 후속 이슈를 기록했습니다.
- 리뷰 포인트: 현재 지원 경로가 `brew install postmelee/tap/hyper-waterfall`이고, `brew install hyper-waterfall` 단독 경로는 #46으로 분리된 점을 확인해 주세요.

## 변경 내역

- **[Stage 1](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/working/task_m040_35_stage1.md)** ([4091506](https://github.com/postmelee/hyper-waterfall/commit/40915067a9823ec500dd1777d2344171195b04be)): public tap 이름, 공개 범위, formula 위치, 외부 공개 작업 승인 조건을 정리했습니다.
- **[Stage 2](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/working/task_m040_35_stage2.md)** ([ed07abc](https://github.com/postmelee/hyper-waterfall/commit/ed07abc064e068c83949d9fad5423a421f79f8a7)): `postmelee/homebrew-tap` public repository를 만들고 `Formula/hyper-waterfall.rb`를 게시했습니다.
- **[Stage 3](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/working/task_m040_35_stage3.md)** ([e9f6c03](https://github.com/postmelee/hyper-waterfall/commit/e9f6c03dedffc88266c5ea10fd9141074f785568)): public tap 기준 install/version/doctor/brew test/cleanup smoke를 검증했습니다.
- **[Stage 4](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/working/task_m040_35_stage4.md)** ([dd92a75](https://github.com/postmelee/hyper-waterfall/commit/dd92a7553687cc39a9065bc4ee6025a031ad46bc)): README와 배포 문서에 Homebrew 설치 안내와 wrapper/canonical 경계를 반영하고 #46을 등록했습니다.
- **[최종 보고](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/report/task_m040_35_report.md)** ([3d7a1f2](https://github.com/postmelee/hyper-waterfall/commit/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de)): 수용 기준 검증, 잔여 위험, 후속 작업, 오늘할일 완료 처리를 정리했습니다.

### 작업 문서

- 수행 계획서: [task_m040_35.md](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/plans/task_m040_35.md)
- 구현 계획서: [task_m040_35_impl.md](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/plans/task_m040_35_impl.md)
- 기술 기록: [task_m040_35_homebrew_public_tap_smoke.md](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md)
- 최종 보고서: [task_m040_35_report.md](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/report/task_m040_35_report.md)

## 핵심 리뷰 포인트

- Homebrew formula는 public tap repository에만 공식 source를 두고, 본 저장소에는 검증 기록과 설치 안내만 남깁니다.
- README의 즉시 설치 경로는 `brew install postmelee/tap/hyper-waterfall`입니다.
- Homebrew는 npm CLI 설치 wrapper이며 GitHub Release/tag, `templates/manifest.json`, migration guide를 대체하지 않습니다.

## 검증

### 자동 검증

| 주제 | 검증 방법 | 결과 | 근거 |
|------|-----------|------|------|
| 산출 문서 존재 | `ls mydocs/plans/task_m040_35.md ... mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md` | OK | 계획서, 구현계획서, Stage 1-4 보고서, 기술 기록이 모두 존재합니다. |
| 설치 안내와 책임 경계 | `rg -n 'brew install postmelee/tap/hyper-waterfall|hyper-waterfall --version|hyper-waterfall doctor --repo|Homebrew public tap|Homebrew core|#46|canonical|wrapper|node' README.md docs ...` | OK | README/docs/Stage 4/기술 기록에서 지원 설치 명령, #46, wrapper/canonical 경계, Node runtime 안내를 확인했습니다. |
| public smoke 근거 | `rg -n '78ca46a54fa34b4251650607264b3fde132cfdfd|34dc90...|brew audit --new --formula|brew install --build-from-source|brew test|read-only|git status --short' ...` | OK | formula commit, tarball SHA256, audit/install/test/read-only smoke 근거를 확인했습니다. |
| git 품질 | `git diff --check`, `git status --short --branch` | OK | 공백 오류 없음. 최종 커밋 후 `local/task35...origin/main [ahead 7]`이며 작업트리는 clean입니다. |

### 수동/시나리오 검증

| 시나리오 | 확인 절차 | 결과 | 자료 |
|----------|-----------|------|------|
| Homebrew public tap smoke | Stage 3에서 `brew tap`, `brew audit`, `brew install --build-from-source`, `--version`, `doctor --repo`, `brew test`, cleanup을 실행 | OK | [기술 기록](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/tech/task_m040_35_homebrew_public_tap_smoke.md) |
| 문서 안내 검토 | README, Homebrew PoC 문서, 배포 채널 문서, v0.2.0 release notes 후보를 확인 | OK | [최종 보고서](https://github.com/postmelee/hyper-waterfall/blob/3d7a1f2ca9c6f6ba4c829d752edfacc18012c4de/mydocs/report/task_m040_35_report.md) |

### CI/원격 검증

| 항목 | 결과 | 근거 |
|------|------|------|
| public tap repository | OK | `gh repo view postmelee/homebrew-tap --json nameWithOwner,visibility,defaultBranchRef,url,pushedAt` -> `PUBLIC`, default branch `main`, pushedAt `2026-05-10T06:29:35Z` |
| 후속 이슈 #46 | OK | `gh issue view 46 --json title,url,state,milestone,labels` -> OPEN, M040, `enhancement`, `infrastructure` |
| base 동기화 | OK | `git fetch origin main` 후 `HEAD..origin/main` 추가 commit 없음 |

### 검증 한계

- 최종 보고 단계에서는 Homebrew install을 다시 실행하지 않았습니다. Stage 3에서 실제 public tap install/test/cleanup smoke를 수행했고, 최종 단계에서는 원격 상태와 문서 근거만 재확인했습니다.
- PR 생성 직후 GitHub Checks는 아직 별도로 확인하지 않았습니다.

## 관련 이슈

- #23
- #33
- #34
- #46

## 후속 이슈 제안

- #46 Homebrew core 등재 가능성 평가와 제출 준비
- release마다 Homebrew formula `url`과 `sha256`을 갱신하는 수동 checklist 또는 자동화 이슈

## 남은 리스크

- `brew install hyper-waterfall` 단독 첫 설치는 아직 지원하지 않습니다. Homebrew core 등재 가능성은 #46에서 별도로 평가합니다.
- release마다 formula `url`과 `sha256`을 갱신하는 운영 방식은 아직 자동화하지 않았습니다.
- Homebrew `node` dependency는 사용자 환경에 따라 `npm`/`npx` link warning을 낼 수 있습니다.
