### PR TITLE
Task #38: Codex plugin 배포 후보 생성과 설치 smoke

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "hyper-waterfall-local",
+  "interface": {
+    "displayName": "Hyper-Waterfall Local Plugins"
+  },
+  "plugins": [
+    {
+      "name": "hyper-waterfall",
+      "source": {
+        "source": "local",
+        "path": "./plugins/hyper-waterfall-codex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/mydocs/orders/20260516.md
+++ b/mydocs/orders/20260516.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #36 | Codex/Claude plugin 공통 배포 원칙 정리 | 완료 | 완료: 18:25 |
 | #37 | Codex plugin packaging 검증 | 완료 | 완료: 19:36 |
-| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 2 완료 후 승인 대기 |
+| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 3 완료 후 승인 대기 |
 | #39 | Claude plugin packaging 검증 | 완료 | 완료: 19:30, Claude plugin packaging 검증과 #40 인계 조건 정리 |

--- a/mydocs/orders/20260516.md
+++ b/mydocs/orders/20260516.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #36 | Codex/Claude plugin 공통 배포 원칙 정리 | 완료 | 완료: 18:25 |
 | #37 | Codex plugin packaging 검증 | 완료 | 완료: 19:36 |
-| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, 구현계획서 작성 후 승인 대기 |
+| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 1 완료 후 승인 대기 |
 | #39 | Claude plugin packaging 검증 | 완료 | 완료: 19:30, Claude plugin packaging 검증과 #40 인계 조건 정리 |

--- a/mydocs/orders/20260516.md
+++ b/mydocs/orders/20260516.md
@@ -6,4 +6,5 @@
 |------|--------|------|------|
 | #36 | Codex/Claude plugin 공통 배포 원칙 정리 | 완료 | 완료: 18:25 |
 | #37 | Codex plugin packaging 검증 | 완료 | 완료: 19:36 |
+| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, 수행계획서 작성 후 승인 대기 |
 | #39 | Claude plugin packaging 검증 | 완료 | 완료: 19:30, Claude plugin packaging 검증과 #40 인계 조건 정리 |

--- a/mydocs/orders/20260516.md
+++ b/mydocs/orders/20260516.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #36 | Codex/Claude plugin 공통 배포 원칙 정리 | 완료 | 완료: 18:25 |
 | #37 | Codex plugin packaging 검증 | 완료 | 완료: 19:36 |
-| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 1 완료 후 승인 대기 |
+| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 2 완료 후 승인 대기 |
 | #39 | Claude plugin packaging 검증 | 완료 | 완료: 19:30, Claude plugin packaging 검증과 #40 인계 조건 정리 |

--- a/mydocs/orders/20260516.md
+++ b/mydocs/orders/20260516.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #36 | Codex/Claude plugin 공통 배포 원칙 정리 | 완료 | 완료: 18:25 |
 | #37 | Codex plugin packaging 검증 | 완료 | 완료: 19:36 |
-| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, 수행계획서 작성 후 승인 대기 |
+| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, 구현계획서 작성 후 승인 대기 |
 | #39 | Claude plugin packaging 검증 | 완료 | 완료: 19:30, Claude plugin packaging 검증과 #40 인계 조건 정리 |

--- a/mydocs/orders/20260516.md
+++ b/mydocs/orders/20260516.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #36 | Codex/Claude plugin 공통 배포 원칙 정리 | 완료 | 완료: 18:25 |
 | #37 | Codex plugin packaging 검증 | 완료 | 완료: 19:36 |
-| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 3 완료 후 승인 대기 |
+| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 4 및 최종 보고서 승인 대기 |
 | #39 | Claude plugin packaging 검증 | 완료 | 완료: 19:30, Claude plugin packaging 검증과 #40 인계 조건 정리 |

--- a/mydocs/orders/20260516.md
+++ b/mydocs/orders/20260516.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #36 | Codex/Claude plugin 공통 배포 원칙 정리 | 완료 | 완료: 18:25 |
 | #37 | Codex plugin packaging 검증 | 완료 | 완료: 19:36 |
-| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 진행중 | M040, Stage 4 및 최종 보고서 승인 대기 |
+| #38 | Codex plugin 배포 후보 생성과 설치 smoke | 완료 | 완료: 20:16 |
 | #39 | Claude plugin packaging 검증 | 완료 | 완료: 19:30, Claude plugin packaging 검증과 #40 인계 조건 정리 |

--- a/mydocs/plans/task_m040_38.md
+++ b/mydocs/plans/task_m040_38.md
@@ -1,0 +1,166 @@
+# Task #38 수행계획서 - Codex plugin 배포 후보 생성과 설치 smoke
+
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+마일스톤: M040
+
+## 목적
+
+Codex plugin packaging 검증 결과를 실제 배포 후보 산출물로 고정하고, Codex 환경에서 설치 또는 로드 smoke가 가능한지 확인한다.
+
+이번 task의 핵심 결과는 hook 없는 thin wrapper 기반 Codex plugin 후보를 만들고, local marketplace 또는 Codex CLI/app 표면에서 install/load/discovery smoke 결과를 기록하는 것이다. public 배포는 smoke 결과와 작업지시자 별도 승인 없이는 실행하지 않는다.
+
+## 배경
+
+M040은 npm, Homebrew, Codex, Claude 채널의 v0.2.0 최종 배포 가능 상태를 만드는 마일스톤이다. #36은 Codex/Claude plugin 공통 배포 원칙을 정리했고, #37은 Codex plugin packaging 사양과 go/no-go를 검증했다.
+
+#37 결론은 #38 1차 후보를 hook 없는 thin wrapper bundle로 두는 것이었다. `.codex-plugin/plugin.json`, `skills: "./skills/"`, `skills/hyper-waterfall/SKILL.md`, plugin README 구성이 공식 path rule과 canonical 원칙을 충족한다는 판단이다. 반면 hook 포함 bundle은 기본값으로는 NO-GO이고, `[features].plugin_hooks = true`와 trust review가 필요한 opt-in 후보로 분리됐다.
+
+이번 task는 #37에서 보류한 실제 bundle 생성, local marketplace 등록 후보, Codex install/load/discovery smoke, fallback 확인, 배포/보류 판단 기록을 수행한다.
+
+참고 문서와 산출물:
+
+- `docs/plugin-distribution-principles.md`
+- `docs/distribution-channels.md`
+- `docs/agent-entrypoint.md`
+- `mydocs/tech/task_m040_37_codex_plugin_packaging_validation.md`
+- `mydocs/report/task_m040_37_report.md`
+- OpenAI Codex plugin 공식 문서
+- OpenAI Codex hooks 공식 문서
+
+## 범위
+
+### 포함
+
+- Codex plugin 공식 문서와 현재 local CLI surface 재확인
+- hook 없는 thin wrapper Codex plugin bundle 후보 생성
+- `.codex-plugin/plugin.json` manifest 작성과 metadata, component path, interface 정보 확정
+- `skills/hyper-waterfall/SKILL.md` thin wrapper 작성
+- plugin README 또는 설치 안내 작성
+- local marketplace 후보 구조 작성
+- Codex install/load/discovery smoke 설계와 실행 가능한 범위의 결과 기록
+- `docs/agent-entrypoint.md`, `AGENTS.md`, `templates/mydocs/skills`, npm CLI dry-run fallback 안내 확인
+- public 배포 실행 여부 판단과 보류 사유 또는 승인 게이트 기록
+- 설치 smoke가 local config/cache를 변경하면 정리 절차 기록
+
+### 제외
+
+- 작업지시자 별도 승인 없는 public 배포 실행
+- Codex plugin hook guardrail 구현
+- `[features].plugin_hooks = true` 활성화를 요구하는 hook 포함 smoke의 기본 범위 편입
+- core Skill 본문을 Codex 전용으로 fork하는 작업
+- `templates/manifest.json`, migration guide, manual 전문을 plugin bundle에 복제하는 작업
+- Claude plugin 배포 후보 생성 또는 smoke
+- Docker image, Homebrew formula, npm publish 변경
+
+## 설계 방향
+
+- 1차 bundle은 hook 없는 thin wrapper 방식으로 만든다.
+- plugin bundle은 `plugins/hyper-waterfall-codex/` 아래에 두고, repo-local marketplace 후보는 `.agents/plugins/marketplace.json`에 둔다.
+- `.codex-plugin/plugin.json`은 plugin root 안의 component만 `./` 상대 경로로 가리킨다.
+- thin wrapper Skill은 canonical Skill 본문을 재작성하지 않고, 현재 저장소의 `AGENTS.md`, `mydocs/skills/{skill-name}/SKILL.md`, `docs/agent-entrypoint.md`, npm CLI dry-run으로 진입하게 한다.
+- public 배포는 이번 task에서 smoke 통과 후에도 별도 승인 게이트로 둔다. 승인 전에는 local candidate와 문서화까지만 수행한다.
+- hook 포함은 기본 bundle에 넣지 않는다. 필요성이 확인되면 후속 이슈 또는 별도 승인 Stage로 분리한다.
+- install/load smoke가 Codex app restart, user config, plugin cache 변경을 요구하면 변경 범위와 cleanup 방법을 단계 보고서에 기록한다.
+- official spec이나 local CLI가 #37 확인 결과와 다르면 #38 산출물을 그에 맞춰 조정하고 차이를 문서화한다.
+
+## 예상 변경 파일
+
+신규:
+
+- `plugins/hyper-waterfall-codex/.codex-plugin/plugin.json`
+- `plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md`
+- `plugins/hyper-waterfall-codex/README.md`
+- `.agents/plugins/marketplace.json`
+- `mydocs/plans/task_m040_38.md`
+- `mydocs/plans/task_m040_38_impl.md`
+- `mydocs/working/task_m040_38_stage1.md`
+- `mydocs/working/task_m040_38_stage2.md`
+- `mydocs/working/task_m040_38_stage3.md`
+- `mydocs/working/task_m040_38_stage4.md`
+- `mydocs/report/task_m040_38_report.md`
+- `mydocs/tech/task_m040_38_codex_plugin_smoke.md`
+
+수정:
+
+- `mydocs/orders/20260516.md`
+- 필요 시 `docs/distribution-channels.md`
+- 필요 시 `docs/plugin-distribution-principles.md`
+
+이번 task 산출물:
+
+- `mydocs/orders/20260516.md`
+- `mydocs/plans/task_m040_38.md`
+- `mydocs/plans/task_m040_38_impl.md`
+- `mydocs/working/task_m040_38_stage{N}.md`
+- `mydocs/report/task_m040_38_report.md`
+
+## 잠정 단계
+
+- **Stage 1 - 사양과 smoke 환경 재확인**
+  - 산출물: Codex plugin 공식 사양 재확인 기록, local CLI/plugin marketplace surface 확인, #37 인계 조건 점검
+  - 검증 관점: #38 bundle 생성 전에 필요한 manifest/path/install 조건과 현재 환경 제약이 분리됐는지 확인
+- **Stage 2 - hook 없는 thin wrapper bundle 생성**
+  - 산출물: `plugins/hyper-waterfall-codex/` bundle, `.codex-plugin/plugin.json`, thin wrapper Skill, README
+  - 검증 관점: bundle이 canonical source를 복제하지 않고 plugin root 내부 component만 참조하는지 확인
+- **Stage 3 - local marketplace와 install/load/discovery smoke**
+  - 산출물: `.agents/plugins/marketplace.json`, install/load/discovery smoke 결과, cleanup 기록
+  - 검증 관점: Codex에서 plugin 후보를 설치 또는 로드할 수 있는지, 실패 시 원인과 보류 조건이 기록됐는지 확인
+- **Stage 4 - fallback, 배포 판단, 최종 보고**
+  - 산출물: `mydocs/tech/task_m040_38_codex_plugin_smoke.md`, public 배포 go/no-go, 최종 보고서
+  - 검증 관점: 사용자가 Codex에서 Hyper-Waterfall 시작 지점과 Skill 흐름을 찾을 수 있고, public 배포 실행/보류 판단이 명확한지 확인
+
+## 검증 계획
+
+### 단계별 검증
+
+- Stage 1
+  - OpenAI Codex plugin 공식 문서 확인일과 URL 기록
+  - `codex --version`
+  - `codex plugin --help`
+  - `codex plugin marketplace --help`
+  - `codex plugin marketplace add --help`
+  - `rg -n '#38|thin wrapper|local marketplace|install/load|smoke|GO|NO-GO' mydocs/tech/task_m040_37_codex_plugin_packaging_validation.md mydocs/report/task_m040_37_report.md`
+- Stage 2
+  - `find plugins/hyper-waterfall-codex -maxdepth 4 -type f | sort`
+  - `jq . plugins/hyper-waterfall-codex/.codex-plugin/plugin.json`
+  - `rg -n 'AGENTS.md|mydocs/skills|docs/agent-entrypoint.md|npx hyper-waterfall|승인|canonical|진실 원천' plugins/hyper-waterfall-codex`
+  - plugin bundle이 `templates/manifest.json`, `docs/migrations/`, `templates/mydocs/manual/` 전문을 포함하지 않는지 확인
+- Stage 3
+  - `jq . .agents/plugins/marketplace.json`
+  - `codex plugin marketplace add` 또는 실행 가능한 local install/load 명령 확인
+  - Codex plugin discovery 또는 실패 사유 기록
+  - 필요한 경우 local config/cache cleanup 확인
+- Stage 4
+  - `npx hyper-waterfall@0.2.0 --help`
+  - `rg -n 'public 배포|go/no-go|보류|fallback|AGENTS|agent-entrypoint|npm CLI|#38' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/report/task_m040_38_report.md`
+  - `rg -n 'Codex plugin|hyper-waterfall-codex|marketplace|plugin.json' docs plugins .agents mydocs/report/task_m040_38_report.md`
+
+### 통합 검증
+
+- Codex plugin 배포 후보 산출물이 존재한다.
+- `.codex-plugin/plugin.json`이 required entry point와 component path 규칙을 만족한다.
+- thin wrapper Skill이 canonical Skill/manual/manifest/migration guide의 새 진실 원천을 만들지 않는다.
+- local marketplace 또는 동등한 local install/load smoke 결과가 기록된다.
+- 사용자가 Codex에서 Hyper-Waterfall 시작 지점과 Skill 흐름을 찾을 수 있다.
+- public 배포가 실행됐거나, 보류 사유와 대체 경로가 문서화된다.
+- `git status --short`가 PR 준비 전 빈 출력이다.
+- `git diff --check`가 경고 없이 통과한다.
+
+## 리스크
+
+- **Codex plugin 사양 변동**: #37 이후에도 Codex plugin 사양이 바뀔 수 있다. Stage 1에서 공식 문서와 local CLI surface를 다시 확인한다.
+- **local smoke 환경 제약**: Codex app restart, plugin cache, user config 접근이 필요하면 완전 자동 smoke가 제한될 수 있다. 가능한 범위와 미수행 사유를 분리해 기록한다.
+- **canonical drift**: thin wrapper가 core Skill을 요약하거나 재작성하면 drift가 생긴다. wrapper는 canonical 파일과 CLI로 진입시키는 안내만 담당한다.
+- **public 배포 승인 혼동**: local smoke 통과가 public 배포 승인을 의미하지 않는다. public 배포는 별도 승인 게이트로 둔다.
+- **hook 범위 확산**: hook guardrail은 기본 bundle에 포함하지 않는다. hook 필요성이 확인되면 후속 승인 또는 별도 이슈로 분리한다.
+- **cleanup 누락**: install smoke가 user config/cache를 바꾸면 제거 절차가 필요하다. smoke 단계에서 변경 지점과 복구 방법을 기록한다.
+
+## 승인 요청 사항
+
+- 수행계획서의 Stage 1-4 흐름에 동의?
+- #38 1차 bundle을 hook 없는 thin wrapper 방식으로 만드는 데 동의?
+- plugin 후보 위치를 `plugins/hyper-waterfall-codex/`, local marketplace 후보 위치를 `.agents/plugins/marketplace.json`로 두는 데 동의?
+- public 배포 실행은 smoke 결과와 별도 승인 전까지 제외하는 데 동의?
+- install/load smoke가 user config/cache 변경을 요구하면 변경 범위를 보고하고 cleanup을 기록하는 데 동의?
+
+승인되면 `task_m040_38_impl.md`에서 단계별 산출물, 검증 명령, 커밋 메시지를 구체화한다.

--- a/mydocs/plans/task_m040_38_impl.md
+++ b/mydocs/plans/task_m040_38_impl.md
@@ -1,0 +1,250 @@
+# Task #38 구현계획서 - Codex plugin 배포 후보 생성과 설치 smoke
+
+수행계획서: [`task_m040_38.md`](task_m040_38.md)
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+마일스톤: M040
+
+## 단계 개요
+
+| Stage | 제목 | 주요 산출 | 검증 |
+|---|---|---|---|
+| 1 | 사양과 smoke 환경 재확인 | `mydocs/tech/task_m040_38_codex_plugin_smoke.md`, `mydocs/working/task_m040_38_stage1.md` | OpenAI 공식 문서 확인일, local Codex CLI/plugin marketplace surface, #37 인계 조건 확인 |
+| 2 | hook 없는 thin wrapper bundle 생성 | `plugins/hyper-waterfall-codex/`, `mydocs/working/task_m040_38_stage2.md` | manifest JSON, plugin root 내부 path, wrapper fallback/canonical 참조 확인 |
+| 3 | local marketplace와 install/load/discovery smoke | `.agents/plugins/marketplace.json`, `mydocs/working/task_m040_38_stage3.md` | marketplace JSON, local add/install/load 가능 여부, cleanup 필요 여부 확인 |
+| 4 | fallback, 배포 판단, 최종 보고 | `mydocs/tech/task_m040_38_codex_plugin_smoke.md`, `mydocs/working/task_m040_38_stage4.md`, `mydocs/report/task_m040_38_report.md` | public 배포 go/no-go, fallback, 최종 수용 기준 확인 |
+
+## Stage 1 - 사양과 smoke 환경 재확인
+
+### 산출물
+
+신규:
+
+- `mydocs/tech/task_m040_38_codex_plugin_smoke.md`
+- `mydocs/working/task_m040_38_stage1.md`
+
+수정:
+
+- `mydocs/orders/20260516.md`
+
+### 변경 내용
+
+- OpenAI Codex plugin 공식 문서와 hooks 공식 문서를 다시 확인하고 확인일, URL, #38에 적용할 packaging/install 조건을 기록한다.
+- local Codex CLI의 plugin command surface를 확인한다.
+- #37 인계 조건 중 `thin wrapper`, `local marketplace`, `install/load smoke`, hook 제외, public 배포 보류 조건을 Stage 1 산출물에 연결한다.
+- 이번 task에서 실제로 smoke 가능한 항목과 Codex app restart 또는 user config 접근 때문에 제한되는 항목을 구분한다.
+- Stage 2 bundle에 적용할 manifest field, plugin version, component path, wrapper 책임 범위를 확정 후보로 둔다.
+
+### 검증
+
+```bash
+codex --version
+codex plugin --help
+codex plugin marketplace --help
+codex plugin marketplace add --help
+rg -n '#38|thin wrapper|local marketplace|install/load|smoke|GO|NO-GO|hook 없는|hook 포함|public 배포' mydocs/tech/task_m040_37_codex_plugin_packaging_validation.md mydocs/report/task_m040_37_report.md
+rg -n 'OpenAI|Codex|plugin|hook|확인일|URL|local marketplace|install|load|smoke|재확인' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/working/task_m040_38_stage1.md
+git diff --check
+```
+
+수동 확인:
+
+- 공식 문서 확인일과 URL이 Stage 1 산출물에 기록됐는지 확인한다.
+- #37의 hook 없는 thin wrapper GO 판단을 변경 없이 이어받는지 확인한다.
+- 확인하지 못한 install/load 항목을 실행 완료처럼 쓰지 않았는지 확인한다.
+
+### 커밋
+
+```text
+Task #38 Stage 1: Codex plugin smoke 환경 재확인
+```
+
+## Stage 2 - hook 없는 thin wrapper bundle 생성
+
+### 산출물
+
+신규:
+
+- `plugins/hyper-waterfall-codex/.codex-plugin/plugin.json`
+- `plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md`
+- `plugins/hyper-waterfall-codex/README.md`
+- `mydocs/working/task_m040_38_stage2.md`
+
+수정:
+
+- `mydocs/tech/task_m040_38_codex_plugin_smoke.md`
+- `mydocs/orders/20260516.md`
+
+### 변경 내용
+
+- `plugins/hyper-waterfall-codex/` 아래에 Codex plugin 후보를 생성한다.
+- `.codex-plugin/plugin.json`에 `name`, `version`, `description`, `repository`, `license`, `keywords`, `skills`, `interface` 정보를 작성한다.
+- `skills` path는 plugin root 내부 `./skills/`만 가리키게 한다.
+- thin wrapper Skill은 Hyper-Waterfall의 canonical source가 아님을 명시하고, 현재 repo의 `AGENTS.md`, `mydocs/skills/{skill-name}/SKILL.md`, `docs/agent-entrypoint.md`, npm CLI dry-run으로 사용자를 안내한다.
+- wrapper는 `task-start`, `task-stage-report`, `task-final-report` 같은 core Skill 절차를 요약 재작성하지 않는다.
+- README는 local candidate 설치/검증 목적과 public 배포 전 승인 게이트를 설명한다.
+- `templates/manifest.json`, migration guide, manual 전문, core Skill fork는 bundle에 포함하지 않는다.
+
+### 검증
+
+```bash
+find plugins/hyper-waterfall-codex -maxdepth 5 -type f | sort
+jq . plugins/hyper-waterfall-codex/.codex-plugin/plugin.json
+rg -n 'AGENTS.md|mydocs/skills|docs/agent-entrypoint.md|npx hyper-waterfall|승인|canonical|진실 원천|not a canonical source|not execute public' plugins/hyper-waterfall-codex
+test ! -e plugins/hyper-waterfall-codex/templates/manifest.json
+test ! -d plugins/hyper-waterfall-codex/docs/migrations
+test ! -d plugins/hyper-waterfall-codex/templates/mydocs/manual
+git diff --check
+```
+
+수동 확인:
+
+- plugin manifest path가 plugin root 밖을 참조하지 않는지 확인한다.
+- thin wrapper가 core Skill 본문을 fork하거나 절차를 재정의하지 않는지 확인한다.
+- hook 관련 파일이나 `[features].plugin_hooks = true` 요구 항목이 기본 bundle에 포함되지 않았는지 확인한다.
+
+### 커밋
+
+```text
+Task #38 Stage 2: Codex thin wrapper bundle 생성
+```
+
+## Stage 3 - local marketplace와 install/load/discovery smoke
+
+### 산출물
+
+신규:
+
+- `.agents/plugins/marketplace.json`
+- `mydocs/working/task_m040_38_stage3.md`
+
+수정:
+
+- `mydocs/tech/task_m040_38_codex_plugin_smoke.md`
+- `mydocs/orders/20260516.md`
+- 필요 시 `plugins/hyper-waterfall-codex/README.md`
+
+### 변경 내용
+
+- repo-local marketplace 후보 `.agents/plugins/marketplace.json`을 작성한다.
+- marketplace `source.path`는 plugin bundle 위치를 가리키되, #37에서 확인한 local marketplace root 상대 path 규칙을 따른다.
+- 가능한 경우 `codex plugin marketplace add` 흐름을 실행해 local marketplace add 또는 install/load surface를 확인한다.
+- Codex CLI 또는 app이 plugin install/load/discovery를 지원하지 않거나 restart/user config 접근이 필요한 경우, 실패 조건과 필요한 수동 확인을 기록한다.
+- smoke 중 user config, plugin cache, local marketplace registration을 변경했다면 변경 위치와 cleanup 절차를 기록한다.
+- wrapper Skill discoverability가 충분하지 않으면 release snapshot 후보 검토 필요성을 Stage 4로 넘긴다.
+
+### 검증
+
+```bash
+jq . .agents/plugins/marketplace.json
+rg -n 'hyper-waterfall|hyper-waterfall-codex|local|source|path|AVAILABLE|Productivity' .agents/plugins/marketplace.json
+codex plugin marketplace add --help
+rg -n 'marketplace|install|load|discovery|cache|config|cleanup|restart|성공|실패|보류' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/working/task_m040_38_stage3.md
+git diff --check
+```
+
+조건부 검증:
+
+```bash
+codex plugin marketplace add ./.agents/plugins
+```
+
+수동 확인:
+
+- 조건부 검증 명령은 local config/cache 변경이 허용되는 경우에만 실행한다.
+- add/install/load 결과가 성공인지, 제한된 smoke인지, 실행 불가인지 명확히 구분한다.
+- cleanup이 필요한 변경을 남기고 단계 완료로 처리하지 않는다.
+
+### 커밋
+
+```text
+Task #38 Stage 3: Codex local marketplace smoke 검증
+```
+
+## Stage 4 - fallback, 배포 판단, 최종 보고
+
+### 산출물
+
+신규:
+
+- `mydocs/working/task_m040_38_stage4.md`
+- `mydocs/report/task_m040_38_report.md`
+
+수정:
+
+- `mydocs/tech/task_m040_38_codex_plugin_smoke.md`
+- 필요 시 `docs/distribution-channels.md`
+- 필요 시 `docs/plugin-distribution-principles.md`
+- `mydocs/orders/20260516.md`
+
+### 변경 내용
+
+- Stage 1-3 결과를 종합해 public 배포 go/no-go를 정리한다.
+- local smoke가 통과하면 public 배포를 즉시 실행하지 않고 별도 승인 요청 조건을 기록한다.
+- local smoke가 제한되거나 실패하면 보류 사유, 대체 설치/사용 경로, 필요한 후속 작업을 기록한다.
+- fallback 경로를 확인한다: `AGENTS.md`, `docs/agent-entrypoint.md`, `templates/mydocs/skills`, npm CLI `npx hyper-waterfall@0.2.0 --help`.
+- Codex 사용자가 Hyper-Waterfall 시작 지점과 core Skill 흐름을 발견할 수 있는지 문서와 plugin wrapper 기준으로 점검한다.
+- 최종 보고서를 작성하고 #38 수용 기준과 검증 결과를 연결한다.
+- 공통 배포 문서 갱신이 필요한 경우에만 `docs/distribution-channels.md` 또는 `docs/plugin-distribution-principles.md`를 좁게 수정한다.
+
+### 검증
+
+```bash
+npx hyper-waterfall@0.2.0 --help
+rg -n 'public 배포|go/no-go|보류|fallback|AGENTS|agent-entrypoint|npm CLI|#38|install|load|discovery' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/report/task_m040_38_report.md
+rg -n 'Codex plugin|hyper-waterfall-codex|marketplace|plugin.json|thin wrapper' docs plugins .agents mydocs/report/task_m040_38_report.md
+git diff --check
+```
+
+수동 확인:
+
+- 최종 보고서가 issue #38 수용 기준을 모두 대응하는지 확인한다.
+- public 배포를 실행했다면 별도 승인 근거와 실행 결과가 기록됐는지 확인한다.
+- public 배포를 보류했다면 보류 사유와 대체 경로가 명확한지 확인한다.
+
+### 커밋
+
+```text
+Task #38 Stage 4: Codex plugin smoke 결과와 배포 판단 정리
+```
+
+## 검증
+
+- 각 Stage 검증 명령은 단계 보고서 작성 전에 실행한다.
+- 실패한 검증은 단계 완료로 처리하지 않는다.
+- 공식 문서 확인은 OpenAI 공식 출처를 우선하고, 확인일과 URL을 산출물에 기록한다.
+- 네트워크 또는 도구 접근 문제로 공식 문서를 확인하지 못하면 해당 항목을 미확인으로 기록하고 Stage 2 bundle 설계를 확정하지 않는다.
+- user config/cache를 변경하는 smoke는 실행 전 변경 범위를 확인하고, 실행 후 cleanup 여부를 보고한다.
+- public 배포는 별도 승인 없이 실행하지 않는다.
+- 계획 변경이 필요하면 구현계획서를 먼저 갱신하고 작업지시자 승인을 받는다.
+
+## 커밋
+
+- 구현계획서 자체는 별도 커밋 `Task #38: 구현계획서 작성`으로 남긴다.
+- 단계 커밋은 해당 단계 산출물과 `mydocs/working/task_m040_38_stage{N}.md`를 함께 묶는다.
+- 커밋 메시지는 `Task #38 Stage {N}: {핵심 내용 요약}` 형식을 따른다.
+- 최종 보고서는 `task-final-report` 절차에서 Stage 4 산출물과 함께 묶거나 별도 완료 처리 커밋으로 처리한다.
+
+## 단계 의존성
+
+- Stage 1은 구현계획서 승인 후 진행한다.
+- Stage 2는 Stage 1에서 manifest/path/install 조건을 재확인한 뒤 진행한다.
+- Stage 3은 Stage 2 bundle 후보가 검증된 뒤 진행한다.
+- Stage 4는 Stage 3의 smoke 결과와 cleanup 상태가 정리된 뒤 진행한다.
+- hook 포함 smoke 또는 public 배포 실행이 필요하면 별도 승인 후 계획을 갱신한다.
+
+## 위험과 대응
+
+- **Codex 사양 변동**: Stage 1에서 공식 문서와 local CLI surface를 다시 확인하고, #37 후보와 차이가 있으면 구현계획 갱신 승인 후 반영한다.
+- **local smoke 부작용**: user config/cache 변경이 필요한 명령은 조건부 검증으로 두고, 실행 시 cleanup 기록을 남긴다.
+- **canonical drift**: wrapper Skill과 README는 canonical Skill/manual/manifest를 재작성하지 않고 경로와 fallback만 안내한다.
+- **public 배포 오해**: local smoke 성공은 public 배포 승인과 별개다. public 배포 실행은 별도 승인 게이트로 둔다.
+- **discoverability 부족**: thin wrapper만으로 core workflow 발견성이 낮으면 release snapshot 후보를 Stage 4 보류/후속 작업으로 기록한다.
+- **network 제약**: `npx hyper-waterfall@0.2.0 --help`나 Codex official docs 확인이 네트워크 제약으로 실패하면 실패 원인과 대체 확인 범위를 보고한다.
+
+## 승인 요청 사항
+
+- Stage 1-4 분할, 산출물, 검증 명령, 커밋 메시지에 동의?
+- Stage 2의 기본 bundle을 hook 없는 thin wrapper로 만들고 hook 포함은 제외하는 데 동의?
+- Stage 3의 `codex plugin marketplace add ./.agents/plugins`는 local config/cache 변경 가능성이 있으므로 실행 전 단계 보고에서 조건부 승인 항목으로 다루는 데 동의?
+- Stage 4에서 public 배포는 smoke 결과와 별도 승인 없이는 실행하지 않는 데 동의?
+- smoke 실패 또는 제한 시 우회 구현 대신 보류 사유와 대체 경로를 최종 보고서에 남기는 데 동의?

--- a/mydocs/plans/task_m040_38_impl.md
+++ b/mydocs/plans/task_m040_38_impl.md
@@ -127,7 +127,7 @@ Task #38 Stage 2: Codex thin wrapper bundle 생성
 
 - repo-local marketplace 후보 `.agents/plugins/marketplace.json`을 작성한다.
 - marketplace `source.path`는 plugin bundle 위치를 가리키되, #37에서 확인한 local marketplace root 상대 path 규칙을 따른다.
-- 가능한 경우 `codex plugin marketplace add` 흐름을 실행해 local marketplace add 또는 install/load surface를 확인한다.
+- 가능한 경우 repo root를 marketplace root로 두고 `codex plugin marketplace add` 흐름을 실행해 local marketplace add 또는 install/load surface를 확인한다.
 - Codex CLI 또는 app이 plugin install/load/discovery를 지원하지 않거나 restart/user config 접근이 필요한 경우, 실패 조건과 필요한 수동 확인을 기록한다.
 - smoke 중 user config, plugin cache, local marketplace registration을 변경했다면 변경 위치와 cleanup 절차를 기록한다.
 - wrapper Skill discoverability가 충분하지 않으면 release snapshot 후보 검토 필요성을 Stage 4로 넘긴다.
@@ -145,7 +145,7 @@ git diff --check
 조건부 검증:
 
 ```bash
-codex plugin marketplace add ./.agents/plugins
+codex plugin marketplace add .
 ```
 
 수동 확인:
@@ -245,6 +245,6 @@ Task #38 Stage 4: Codex plugin smoke 결과와 배포 판단 정리
 
 - Stage 1-4 분할, 산출물, 검증 명령, 커밋 메시지에 동의?
 - Stage 2의 기본 bundle을 hook 없는 thin wrapper로 만들고 hook 포함은 제외하는 데 동의?
-- Stage 3의 `codex plugin marketplace add ./.agents/plugins`는 local config/cache 변경 가능성이 있으므로 실행 전 단계 보고에서 조건부 승인 항목으로 다루는 데 동의?
+- Stage 3의 `codex plugin marketplace add .`는 local config/cache 변경 가능성이 있으므로 실행 전 단계 보고에서 조건부 승인 항목으로 다루는 데 동의?
 - Stage 4에서 public 배포는 smoke 결과와 별도 승인 없이는 실행하지 않는 데 동의?
 - smoke 실패 또는 제한 시 우회 구현 대신 보류 사유와 대체 경로를 최종 보고서에 남기는 데 동의?

--- a/mydocs/report/task_m040_38_report.md
+++ b/mydocs/report/task_m040_38_report.md
@@ -1,0 +1,95 @@
+# Task #38 최종 보고서 - Codex plugin 배포 후보 생성과 설치 smoke
+
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+마일스톤: M040
+
+## 작업 요약
+
+- 대상 이슈: #38
+- 마일스톤: M040
+- 단계 수: 4
+- 작업 목적: Codex plugin packaging 검증 결과를 실제 repo-local 배포 후보로 만들고, local marketplace smoke와 fallback 경로를 확인한다.
+
+## 변경 파일 목록과 영향 범위
+
+| 경로 | 변경 요약 | 영향 범위 |
+|---|---|---|
+| `plugins/hyper-waterfall-codex/.codex-plugin/plugin.json` | Codex plugin manifest 생성. `skills: "./skills/"`, install-surface metadata, `Read` capability 설정 | Codex plugin 후보 |
+| `plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md` | Hyper-Waterfall thin wrapper Skill 생성. canonical 파일과 npm CLI dry-run으로 안내 | Codex Skill discovery |
+| `plugins/hyper-waterfall-codex/README.md` | plugin 후보 목적, 설계 원칙, local smoke, public 배포 게이트 설명 | Reviewer와 maintainer 안내 |
+| `.agents/plugins/marketplace.json` | repo-local marketplace 후보 생성 | Codex local marketplace smoke |
+| `mydocs/tech/task_m040_38_codex_plugin_smoke.md` | 공식 사양, bundle 생성 결과, local marketplace smoke, fallback, go/no-go 기록 | #38 검증 근거 |
+| `mydocs/working/task_m040_38_stage1.md` | 사양과 smoke 환경 재확인 단계 보고 | Stage 1 검증 기록 |
+| `mydocs/working/task_m040_38_stage2.md` | hook 없는 thin wrapper bundle 생성 단계 보고 | Stage 2 검증 기록 |
+| `mydocs/working/task_m040_38_stage3.md` | local marketplace와 install/load/discovery smoke 단계 보고 | Stage 3 검증 기록 |
+| `mydocs/working/task_m040_38_stage4.md` | fallback, 배포 판단, 최종 보고 단계 보고 | Stage 4 검증 기록 |
+| `mydocs/plans/task_m040_38.md` | 수행계획서 작성 | Task #38 승인 범위 |
+| `mydocs/plans/task_m040_38_impl.md` | 구현계획서 작성과 Stage 3 command 보정 | Stage 분할, 검증, 커밋 기준 |
+| `mydocs/orders/20260516.md` | Task #38 진행 상태 갱신 | 오늘할일 추적 |
+
+## 변경 전·후 정량 비교
+
+| 지표 | 변경 전 | 변경 후 |
+|---|---|---|
+| Codex plugin 후보 파일 | 없음 | manifest 1개, wrapper Skill 1개, README 1개 |
+| Repo-local marketplace | 없음 | `.agents/plugins/marketplace.json` 1개 |
+| Stage 보고서 | 없음 | Stage 1-4 보고서 4개 |
+| 기술 검증 문서 | 없음 | `task_m040_38_codex_plugin_smoke.md` 1개 |
+| Public 배포 실행 | 없음 | 없음. 별도 승인 전 보류 |
+| Hook 구현 | 없음 | 없음. 기본 bundle에서 제외 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 |
+|---|---|
+| Codex plugin 배포 후보 산출물 또는 명확한 배포 절차가 존재한다 | OK — `plugins/hyper-waterfall-codex/`에 `.codex-plugin/plugin.json`, thin wrapper Skill, README를 생성했다. |
+| Codex 환경에서 설치 또는 로드 smoke 결과가 기록된다 | OK with limit — `codex plugin marketplace add .`가 repo-local marketplace를 성공적으로 등록했다. 실제 Plugin Directory 표시와 Skill invocation은 restart/UI 확인이 필요하다고 기록했다. |
+| 사용자가 Codex에서 Hyper-Waterfall 시작 지점과 Skill 흐름을 찾을 수 있다 | OK with limit — plugin wrapper와 README가 `AGENTS.md`, `mydocs/skills/{skill-name}/SKILL.md`, `docs/agent-entrypoint.md`, npm CLI dry-run 경로를 안내한다. UI discovery는 수동 확인 필요다. |
+| public 배포가 실행됐거나, 보류 사유와 대체 경로가 문서화된다 | OK — public 배포는 별도 승인 부재와 UI discovery 수동 확인 필요 때문에 보류했고, 대체 경로를 `AGENTS.md`, `docs/agent-entrypoint.md`, `templates/mydocs/skills/`, npm CLI로 문서화했다. |
+| Hook 없는 thin wrapper 기준을 유지한다 | OK — manifest에 `hooks`, `apps`, `mcpServers`를 넣지 않았고, hook 포함은 후속 승인 대상으로 남겼다. |
+| canonical source를 복제하지 않는다 | OK — plugin bundle에 `templates/manifest.json`, migration guide, manual 전문, core Skill fork를 포함하지 않았다. |
+
+### 단계별 검증 결과
+
+- Stage 1: [`task_m040_38_stage1.md`](../working/task_m040_38_stage1.md) — OpenAI 공식 plugin/hooks 문서, local CLI surface, #37 인계 조건 재확인.
+- Stage 2: [`task_m040_38_stage2.md`](../working/task_m040_38_stage2.md) — manifest JSON, plugin root 내부 path, thin wrapper canonical/fallback 문구 확인.
+- Stage 3: [`task_m040_38_stage3.md`](../working/task_m040_38_stage3.md) — repo-local marketplace JSON, `codex plugin marketplace add .` smoke, cleanup 확인.
+- Stage 4: [`task_m040_38_stage4.md`](../working/task_m040_38_stage4.md) — fallback, npm CLI help, public 배포 go/no-go 확인.
+
+### 최종 검증 명령
+
+```bash
+npx hyper-waterfall@0.2.0 --help
+rg -n 'public 배포|go/no-go|보류|fallback|AGENTS|agent-entrypoint|npm CLI|#38|install|load|discovery' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/report/task_m040_38_report.md
+rg -n 'Codex plugin|hyper-waterfall-codex|marketplace|plugin.json|thin wrapper' docs plugins .agents mydocs/report/task_m040_38_report.md
+git diff --check
+```
+
+결과:
+
+- OK: 빈 임시 디렉터리에서 `npx hyper-waterfall@0.2.0 --help`가 `init`, `update`, `doctor`, canonical 기준 안내를 출력했다.
+- OK: task worktree root에서 같은 npx 명령이 실패하는 known source-root 해석 차이를 검증 한계로 기록했다.
+- OK: public 배포, go/no-go, 보류, fallback, AGENTS, agent-entrypoint, npm CLI, install/load/discovery 항목을 기술 노트와 최종 보고서에서 확인했다.
+- OK: Codex plugin, `hyper-waterfall-codex`, marketplace, `plugin.json`, thin wrapper 항목을 docs/plugin/marketplace/보고서에서 확인했다.
+- OK: `git diff --check`가 출력 없이 통과했다.
+
+## 잔여 위험과 후속 작업
+
+### 잔여 위험
+
+- Codex app/CLI interactive Plugin Directory에서 실제 표시와 Skill invocation은 restart/UI 확인이 필요하다.
+- Public 배포는 별도 승인 전 실행하지 않았다.
+- Public 배포용 visual asset, screenshot, privacy/terms URL 같은 install-surface 보강이 필요할 수 있다.
+- Thin wrapper discoverability가 부족하면 release snapshot bundle 후보를 재검토해야 한다.
+- Hook guardrail은 #38 기본 bundle에서 제외됐다.
+
+### 후속 작업 후보
+
+- Codex Plugin Directory UI discovery와 Skill invocation 수동 smoke
+- Public 배포 승인 시 install-surface asset/legal link 보강
+- Thin wrapper discoverability가 부족하면 release snapshot bundle 검토
+- Hook guardrail 구현과 fixture test가 필요하면 별도 이슈로 분리
+
+## 작업지시자 승인 요청
+
+- 최종 보고서와 수용 기준 검증 결과를 승인하면 PR 게시 절차로 진행한다.

--- a/mydocs/report/task_m040_38_report.md
+++ b/mydocs/report/task_m040_38_report.md
@@ -85,8 +85,7 @@ git diff --check
 
 ### 후속 작업 후보
 
-- Codex Plugin Directory UI discovery와 Skill invocation 수동 smoke
-- Public 배포 승인 시 install-surface asset/legal link 보강
+- [#52 Codex plugin public 배포와 UI discovery smoke](https://github.com/postmelee/hyper-waterfall/issues/52): Codex Plugin Directory UI discovery, Skill invocation 수동 smoke, public 배포 승인 게이트, install-surface asset/legal link 검토
 - Thin wrapper discoverability가 부족하면 release snapshot bundle 검토
 - Hook guardrail 구현과 fixture test가 필요하면 별도 이슈로 분리
 

--- a/mydocs/tech/task_m040_38_codex_plugin_smoke.md
+++ b/mydocs/tech/task_m040_38_codex_plugin_smoke.md
@@ -108,3 +108,62 @@ codex plugin marketplace add .
 - Stage 3 local marketplace smoke는 repo root를 marketplace root로 두는 방향으로 보정해야 한다.
 - Hook 포함과 public 배포는 Stage 1 기준으로도 별도 승인 전 실행하지 않는다.
 - Stage 2 전에 공식 사양 때문에 막히는 항목은 없다.
+
+## Stage 2 bundle 생성 결과
+
+Stage 2에서는 Stage 1에서 확정한 hook 없는 thin wrapper 구조를 실제 repository 산출물로 생성했다.
+
+생성 파일:
+
+```text
+plugins/hyper-waterfall-codex/.codex-plugin/plugin.json
+plugins/hyper-waterfall-codex/README.md
+plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md
+```
+
+### Manifest 결과
+
+| field | 값 | 판단 |
+|---|---|---|
+| `name` | `hyper-waterfall` | kebab-case stable identifier로 사용 가능 |
+| `version` | `0.2.0` | v0.2.0 배포 후보와 맞춤. plugin artifact version과 framework version의 혼동은 README와 보고서에서 관리 |
+| `description` | `Discover Hyper-Waterfall workflows and lifecycle checks in Codex.` | install surface 설명 |
+| `repository` | `https://github.com/postmelee/hyper-waterfall` | canonical repository 참조 |
+| `license` | `MIT` | repository license와 일치 |
+| `keywords` | `workflow`, `codex`, `project-management` | discovery metadata |
+| `skills` | `./skills/` | plugin root 내부 상대 경로, 공식 path rule 충족 |
+| `interface.capabilities` | `["Read"]` | thin wrapper의 읽기/안내 성격에 맞춰 제한 |
+
+기본 bundle에는 `hooks`, `apps`, `mcpServers`, `assets`를 넣지 않았다.
+
+### Thin wrapper 결과
+
+`skills/hyper-waterfall/SKILL.md`는 다음 원칙을 따른다.
+
+- `This plugin is not a canonical source.`라고 명시했다.
+- 현재 저장소의 `AGENTS.md`를 먼저 읽게 한다.
+- 정형 task 절차는 현재 저장소의 `mydocs/skills/{skill-name}/SKILL.md`를 읽게 한다.
+- 신규 적용과 기존 업데이트 판단은 `docs/agent-entrypoint.md`, `templates/manifest.json`, `docs/migrations/`, npm CLI dry-run으로 보낸다.
+- 승인 없이 파일 수정, issue close, PR merge, publish, release 생성을 하지 말라고 명시했다.
+- fallback은 canonical 파일을 찾지 못할 때 사용자에게 저장소 루트와 release 기준 확인을 요청하는 수준으로 제한했다.
+
+### README 결과
+
+`README.md`는 local candidate의 목적, 포함 파일, 설계 원칙, local smoke 후보, 공개 배포 게이트를 설명한다. Stage 3에서 사용할 조건부 command 후보는 repo root 기준 `codex plugin marketplace add .`로 기록했다.
+
+### Stage 2 검증 결과
+
+| 항목 | 결과 | 근거 |
+|---|---|---|
+| 파일 구조 | OK | `find plugins/hyper-waterfall-codex -maxdepth 5 -type f`가 manifest, README, wrapper Skill 세 파일만 출력 |
+| Manifest JSON | OK | `jq . plugins/hyper-waterfall-codex/.codex-plugin/plugin.json` 통과 |
+| Canonical/fallback 문구 | OK | `AGENTS.md`, `mydocs/skills`, `docs/agent-entrypoint.md`, `npx hyper-waterfall`, `승인`, `canonical`, `진실 원천`, `not a canonical source`, `not execute public` 확인 |
+| Manifest 복제 금지 | OK | `plugins/hyper-waterfall-codex/templates/manifest.json` 없음 |
+| Migration 복제 금지 | OK | `plugins/hyper-waterfall-codex/docs/migrations` 없음 |
+| Manual 복제 금지 | OK | `plugins/hyper-waterfall-codex/templates/mydocs/manual` 없음 |
+
+### Stage 2 결론
+
+- Stage 2 bundle 후보는 공식 Codex plugin path rule과 #37 canonical 원칙을 충족한다.
+- 기본 bundle은 hook 없는 thin wrapper로 유지됐다.
+- Stage 3에서는 repo-local marketplace 파일을 만들고, local config/cache 변경 가능성이 있는 `codex plugin marketplace add .` 실행 여부를 별도 확인해야 한다.

--- a/mydocs/tech/task_m040_38_codex_plugin_smoke.md
+++ b/mydocs/tech/task_m040_38_codex_plugin_smoke.md
@@ -248,3 +248,58 @@ Stage 3에서는 repo-local marketplace 후보를 만들고 Codex CLI에서 loca
 - Codex CLI local marketplace add smoke는 성공했다.
 - 자동 install/load/discovery 전체 검증은 CLI surface 한계와 Codex restart/UI 요구 때문에 제한됐다.
 - Stage 4에서는 public 배포 판단을 "local add smoke 성공, UI discovery 수동 확인 필요"로 정리해야 한다.
+
+## Stage 4 fallback과 배포 판단
+
+Stage 4에서는 fallback 경로, npm CLI help, public 배포 go/no-go를 정리했다.
+
+### Fallback 확인
+
+| fallback | 확인 결과 | 판단 |
+|---|---|---|
+| `AGENTS.md` | repository root에 존재하며 하이퍼-워터폴 운영 규칙과 승인 게이트를 제공한다. | OK |
+| `docs/agent-entrypoint.md` | 신규 적용과 기존 업데이트 판단 결과 형식을 제공한다. | OK |
+| `templates/mydocs/skills/` | `task-start`, `task-stage-report`, `task-final-report`, `pr-merge-cleanup` 등 core Skill 원문이 존재한다. | OK |
+| npm CLI | 빈 임시 디렉터리에서 `npx hyper-waterfall@0.2.0 --help`가 성공하고 `init`, `update`, `doctor`, canonical 기준 안내를 출력했다. | OK |
+
+### npm CLI help 검증
+
+처음에는 task worktree root에서 `npx hyper-waterfall@0.2.0 --help`를 실행했고 `sh: hyper-waterfall: command not found`가 발생했다. `docs/releases/v0.2.0-npm-publish.md`에 기록된 것처럼 같은 package name의 source root에서는 local package 우선 해석 때문에 이 현상이 발생할 수 있다.
+
+사용자 설치 경로에 가까운 빈 임시 디렉터리 `/private/tmp/hyper-waterfall-task38-npx.56eXYW`에서 같은 명령을 재실행했고 성공했다.
+
+출력 요약:
+
+```text
+Hyper-Waterfall CLI
+Commands:
+  init
+  update
+  doctor
+This CLI is a convenience execution channel. GitHub Release/tag,
+templates/manifest.json, and migration guides remain canonical.
+```
+
+판단:
+
+- npm CLI fallback은 사용자 설치 경로 기준으로 정상이다.
+- source root 실패는 #38 plugin 후보 실패가 아니라 검증 위치에 따른 `npx` 해석 차이다.
+- plugin wrapper와 README의 npm CLI 안내는 유지 가능하다.
+
+### Public 배포 go/no-go
+
+| 항목 | 판단 | 근거 |
+|---|---|---|
+| Repo-local candidate 유지 | GO | plugin bundle, repo marketplace, local add smoke가 통과했다. |
+| PR 게시 | GO after approval | 산출물과 검증 결과가 문서화됐고, PR 리뷰로 배포 후보를 고정할 수 있다. |
+| Public 배포 실행 | NO-GO without separate approval | public 배포는 별도 승인 게이트 대상이며, 이번 Stage에서 작업지시자가 public 배포를 명시 승인하지 않았다. |
+| Public 배포 품질 | CONDITIONAL | local add smoke는 성공했지만 Plugin Directory UI discovery와 Skill invocation은 Codex restart/UI 확인이 필요하다. |
+| Hook 포함 배포 | NO-GO | 기본 bundle에 hook을 포함하지 않기로 한 #37/#38 판단을 유지한다. |
+| Release snapshot bundle | 보류 | Thin wrapper 후보가 만들어졌고 local add smoke가 통과했으므로, snapshot은 discoverability 부족이 확인될 때만 후속 후보로 둔다. |
+
+### Stage 4 결론
+
+- #38은 Codex plugin repo-local 배포 후보를 생성했고, local marketplace add smoke까지 통과했다.
+- public 배포 실행은 별도 승인 전 보류한다.
+- 자동 install/load/discovery 전체 검증은 Codex restart/UI 확인이 필요하므로 제한 사항으로 남긴다.
+- 대체 경로는 `AGENTS.md`, `docs/agent-entrypoint.md`, `templates/mydocs/skills/`, npm CLI fallback으로 유지된다.

--- a/mydocs/tech/task_m040_38_codex_plugin_smoke.md
+++ b/mydocs/tech/task_m040_38_codex_plugin_smoke.md
@@ -297,9 +297,12 @@ templates/manifest.json, and migration guides remain canonical.
 | Hook 포함 배포 | NO-GO | 기본 bundle에 hook을 포함하지 않기로 한 #37/#38 판단을 유지한다. |
 | Release snapshot bundle | 보류 | Thin wrapper 후보가 만들어졌고 local add smoke가 통과했으므로, snapshot은 discoverability 부족이 확인될 때만 후속 후보로 둔다. |
 
+후속 public 배포와 UI discovery smoke는 [#52](https://github.com/postmelee/hyper-waterfall/issues/52)로 등록했다.
+
 ### Stage 4 결론
 
 - #38은 Codex plugin repo-local 배포 후보를 생성했고, local marketplace add smoke까지 통과했다.
 - public 배포 실행은 별도 승인 전 보류한다.
 - 자동 install/load/discovery 전체 검증은 Codex restart/UI 확인이 필요하므로 제한 사항으로 남긴다.
 - 대체 경로는 `AGENTS.md`, `docs/agent-entrypoint.md`, `templates/mydocs/skills/`, npm CLI fallback으로 유지된다.
+- public 배포와 UI discovery smoke는 #52에서 이어간다.

--- a/mydocs/tech/task_m040_38_codex_plugin_smoke.md
+++ b/mydocs/tech/task_m040_38_codex_plugin_smoke.md
@@ -167,3 +167,84 @@ plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md
 - Stage 2 bundle 후보는 공식 Codex plugin path rule과 #37 canonical 원칙을 충족한다.
 - 기본 bundle은 hook 없는 thin wrapper로 유지됐다.
 - Stage 3에서는 repo-local marketplace 파일을 만들고, local config/cache 변경 가능성이 있는 `codex plugin marketplace add .` 실행 여부를 별도 확인해야 한다.
+
+## Stage 3 local marketplace smoke 결과
+
+Stage 3에서는 repo-local marketplace 후보를 만들고 Codex CLI에서 local marketplace root를 받아들이는지 확인했다.
+
+### Marketplace 후보
+
+파일: `.agents/plugins/marketplace.json`
+
+```json
+{
+  "name": "hyper-waterfall-local",
+  "interface": {
+    "displayName": "Hyper-Waterfall Local Plugins"
+  },
+  "plugins": [
+    {
+      "name": "hyper-waterfall",
+      "source": {
+        "source": "local",
+        "path": "./plugins/hyper-waterfall-codex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+```
+
+판단:
+
+- `source.path`는 marketplace root 기준 `./plugins/hyper-waterfall-codex`다.
+- repository root를 local marketplace root로 넘기는 `codex plugin marketplace add .` 흐름과 맞는다.
+- 이 파일은 repo-local candidate이며, personal marketplace 파일을 만들지 않았다.
+
+### CLI smoke
+
+실행 위치: `/private/tmp/hyper-waterfall-task38`
+
+| 명령 | 결과 | 판단 |
+|---|---|---|
+| `jq . .agents/plugins/marketplace.json` | 성공 | marketplace JSON syntax OK |
+| `rg -n 'hyper-waterfall|hyper-waterfall-codex|local|source|path|AVAILABLE|Productivity' .agents/plugins/marketplace.json` | 성공 | local marketplace metadata 확인 |
+| `codex plugin marketplace add --help` | 성공 | local marketplace root directory source 지원 재확인 |
+| `codex plugin marketplace add .` | `Added marketplace 'hyper-waterfall-local' from /private/tmp/hyper-waterfall-task38.` / `Installed marketplace root: /private/tmp/hyper-waterfall-task38` | Codex CLI가 repo root local marketplace를 수용함 |
+| `codex plugin marketplace upgrade hyper-waterfall-local` | `Error: marketplace 'hyper-waterfall-local' is not configured as a Git marketplace` | local marketplace는 Git marketplace upgrade 대상이 아님. 실패가 plugin 구조 실패를 의미하지 않음 |
+| `codex plugin marketplace remove hyper-waterfall-local` | `Removed marketplace 'hyper-waterfall-local'.` | smoke 후 local registration cleanup 완료 |
+
+### Install/load/discovery 판단
+
+- CLI add smoke는 성공했다. Codex가 repo root를 local marketplace root로 인식했고 marketplace name을 읽었다.
+- CLI에는 이 환경에서 plugin install/list/load를 직접 확인하는 추가 subcommand가 노출되지 않았다.
+- 공식 문서상 repo marketplace는 Codex restart 후 Plugin Directory 또는 CLI `/plugins`에서 확인하는 흐름이므로, 실제 UI discovery는 자동 검증 대신 수동 확인 항목으로 남긴다.
+- Stage 3에서는 personal marketplace나 plugin cache 파일을 repository에 추가하지 않았다.
+- `codex plugin marketplace remove hyper-waterfall-local`로 등록 부산물을 제거했다.
+
+### Cleanup
+
+변경된 repository 파일:
+
+- `.agents/plugins/marketplace.json`
+
+임시 local registration:
+
+- `codex plugin marketplace add .`로 등록
+- `codex plugin marketplace remove hyper-waterfall-local`로 제거
+
+잔여 config/cache:
+
+- CLI remove 명령은 성공했다.
+- Codex CLI에는 marketplace list 명령이 없어 별도 listing 검증은 하지 못했다.
+
+### Stage 3 결론
+
+- Repo-local marketplace 파일은 공식 구조와 path rule을 충족한다.
+- Codex CLI local marketplace add smoke는 성공했다.
+- 자동 install/load/discovery 전체 검증은 CLI surface 한계와 Codex restart/UI 요구 때문에 제한됐다.
+- Stage 4에서는 public 배포 판단을 "local add smoke 성공, UI discovery 수동 확인 필요"로 정리해야 한다.

--- a/mydocs/tech/task_m040_38_codex_plugin_smoke.md
+++ b/mydocs/tech/task_m040_38_codex_plugin_smoke.md
@@ -1,0 +1,110 @@
+# Task #38 Codex plugin smoke validation
+
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+확인일: 2026-05-16
+
+## 목적
+
+이 문서는 Codex plugin 배포 후보 생성과 설치 smoke의 기준을 기록한다. Stage 1에서는 실제 bundle을 만들지 않고, 공식 사양, local CLI surface, #37 인계 조건을 다시 확인해 Stage 2-4의 실행 기준을 고정한다.
+
+## 공식 문서 재확인
+
+| 문서 | URL | #38 적용 항목 |
+|---|---|---|
+| Codex Plugins | https://developers.openai.com/codex/plugins | plugin은 Skill, app integration, MCP server를 reusable workflow로 묶는 단위이며, Codex app plugin directory와 CLI `/plugins`에서 browse/install surface를 제공한다. |
+| Codex Build plugins | https://developers.openai.com/codex/plugins/build | `.codex-plugin/plugin.json` required entry point, `skills: "./skills/"`, repo marketplace, local marketplace source, manifest field/path rule을 확인했다. |
+| Codex Hooks | https://developers.openai.com/codex/hooks | plugin-bundled hook은 `[features].plugin_hooks = true` opt-in이며, 기본 bundle에는 포함하지 않는다는 #37 판단을 재확인했다. |
+
+## Stage 1 공식 사양 요약
+
+| 항목 | 확인 결과 | #38 적용 |
+|---|---|---|
+| Plugin 단위 | Plugin은 Codex에서 reusable workflow를 제공하기 위해 skills, apps, MCP servers를 bundle할 수 있다. | #38 기본 bundle은 Skill만 포함한다. Apps/MCP는 제외한다. |
+| Required manifest | `.codex-plugin/plugin.json`이 required entry point다. | Stage 2에서 이 파일을 생성한다. |
+| Minimal skill plugin | 최소 구조는 plugin folder, `.codex-plugin/plugin.json`, `skills/<skill-name>/SKILL.md`다. | `plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md`를 만든다. |
+| Manifest metadata | `name`, `version`, `description`은 plugin 식별 정보이고, `skills`, `mcpServers`, `apps`, `hooks`는 bundled component를 plugin root 상대 경로로 가리킨다. | manifest에는 `skills: "./skills/"`만 포함하고 hooks/apps/MCP는 넣지 않는다. |
+| Path rule | manifest path는 plugin root 상대 `./` 경로여야 한다. | `skills`와 향후 assets path는 plugin root 내부로 제한한다. |
+| Repo marketplace | repo marketplace는 `$REPO_ROOT/.agents/plugins/marketplace.json`을 사용하고 plugin은 `$REPO_ROOT/plugins/` 아래에 둔다. | Stage 3에서 `.agents/plugins/marketplace.json`과 `plugins/hyper-waterfall-codex/` 구조를 사용한다. |
+| Marketplace path 기준 | `source.path`는 `.agents/plugins/` 폴더가 아니라 marketplace root 기준으로 해석된다. | local CLI add 후보는 repo root에서 `codex plugin marketplace add .`로 보정한다. |
+| CLI marketplace source | CLI는 GitHub shorthand, Git URL, SSH URL, local marketplace root directory를 source로 받을 수 있다. | Stage 3에서 repo root를 local marketplace root 후보로 둔다. |
+| Plugin-bundled hook | plugin hook은 현재 release에서 opt-in이고 `[features].plugin_hooks = true`가 필요하다. | #38 기본 bundle에서 `hooks` field와 `hooks/` directory를 제외한다. |
+| Hook matcher/coverage | `PreToolUse`, `PermissionRequest`, `PostToolUse` 등 일부 이벤트가 matcher를 지원하지만 shell/tool interception은 완전한 enforcement boundary가 아니다. | hook guardrail은 #38 기본 smoke 범위가 아니다. |
+
+## Local CLI surface
+
+실행 위치: `/private/tmp/hyper-waterfall-task38`
+
+| 명령 | 결과 요약 |
+|---|---|
+| `codex --version` | `codex-cli 0.131.0-alpha.9` 확인. PATH update warning은 있었지만 version 출력은 성공했다. |
+| `codex plugin --help` | `marketplace` subcommand 확인. |
+| `codex plugin marketplace --help` | `add`, `upgrade`, `remove` subcommand 확인. |
+| `codex plugin marketplace add --help` | `<SOURCE>`가 `owner/repo[@ref]`, HTTP(S) Git URL, SSH URL, local marketplace root directory를 지원한다고 확인. |
+
+## #37 인계 조건 점검
+
+| #37 인계 항목 | Stage 1 판단 | Stage 2-4 처리 |
+|---|---|---|
+| Hook 없는 thin wrapper bundle | GO | Stage 2에서 `plugins/hyper-waterfall-codex/` 아래에 생성한다. |
+| Release snapshot bundle | CONDITIONAL | Thin wrapper discovery가 부족할 때 Stage 4 후속 후보로만 기록한다. |
+| Hook 포함 bundle | 기본 NO-GO, opt-in CONDITIONAL | 이번 기본 bundle과 Stage 3 smoke에서는 제외한다. |
+| App/MCP 포함 | NO-GO | 제외한다. |
+| Public 배포 | #38에서도 별도 승인 전 실행 금지 | Stage 4에서 go/no-go와 승인 요청 조건만 기록한다. |
+| Local marketplace smoke | #38 범위 | Stage 3에서 repo root marketplace 기준으로 확인한다. |
+| Plugin cache/config cleanup | smoke 실행 시 필요 | Stage 3에서 변경 위치와 cleanup을 기록한다. |
+
+## Stage 2 확정 후보
+
+```text
+plugins/hyper-waterfall-codex/
+  .codex-plugin/
+    plugin.json
+  skills/
+    hyper-waterfall/
+      SKILL.md
+  README.md
+```
+
+Stage 2 manifest 후보:
+
+```json
+{
+  "name": "hyper-waterfall",
+  "version": "0.2.0",
+  "description": "Discover Hyper-Waterfall workflows and lifecycle checks in Codex.",
+  "repository": "https://github.com/postmelee/hyper-waterfall",
+  "license": "MIT",
+  "keywords": ["workflow", "codex", "project-management"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Hyper-Waterfall",
+    "shortDescription": "Issue-first waterfall workflow guardrails for coding agents.",
+    "longDescription": "Use Hyper-Waterfall workflow entrypoints, lifecycle checks, and fallback guidance from Codex without making the plugin a new canonical source.",
+    "developerName": "postmelee",
+    "category": "Productivity",
+    "capabilities": ["Read"],
+    "websiteURL": "https://github.com/postmelee/hyper-waterfall",
+    "defaultPrompt": [
+      "Use Hyper-Waterfall to start the current GitHub issue workflow.",
+      "Use Hyper-Waterfall to check whether this repository should be initialized or updated."
+    ]
+  }
+}
+```
+
+## Stage 3 smoke 기준 보정
+
+구현계획서 초안의 조건부 명령은 `codex plugin marketplace add ./.agents/plugins`였으나, 공식 문서 기준으로는 marketplace root directory를 넘겨야 한다. repo marketplace 파일은 `$REPO_ROOT/.agents/plugins/marketplace.json`에 있고 `source.path`는 marketplace root 기준으로 해석되므로, #38 Stage 3의 조건부 명령 후보는 다음으로 보정한다.
+
+```bash
+codex plugin marketplace add .
+```
+
+이 명령은 local config/cache를 변경할 수 있으므로 Stage 3에서 작업지시자 승인 항목으로 다시 확인한다.
+
+## Stage 1 결론
+
+- #38 Stage 2는 hook 없는 thin wrapper bundle 생성으로 진행 가능하다.
+- Stage 3 local marketplace smoke는 repo root를 marketplace root로 두는 방향으로 보정해야 한다.
+- Hook 포함과 public 배포는 Stage 1 기준으로도 별도 승인 전 실행하지 않는다.
+- Stage 2 전에 공식 사양 때문에 막히는 항목은 없다.

--- a/mydocs/working/task_m040_38_stage1.md
+++ b/mydocs/working/task_m040_38_stage1.md
@@ -1,0 +1,69 @@
+# Task #38 Stage 1 보고서 - 사양과 smoke 환경 재확인
+
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+구현계획서: [`task_m040_38_impl.md`](../plans/task_m040_38_impl.md)
+Stage: 1
+
+## 단계 목적
+
+Stage 1은 Codex plugin 배포 후보를 만들기 전에 공식 OpenAI 문서와 local Codex CLI surface를 재확인하고, #37에서 넘어온 thin wrapper, local marketplace, hook 제외, public 배포 보류 조건을 #38 실행 기준으로 고정하는 단계다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `mydocs/tech/task_m040_38_codex_plugin_smoke.md` | 공식 사양 재확인, local CLI surface, #37 인계 조건, Stage 2 bundle 후보, Stage 3 marketplace command 보정 기록 |
+| `mydocs/working/task_m040_38_stage1.md` | Stage 1 단계 보고서 작성 |
+| `mydocs/plans/task_m040_38_impl.md` | Stage 3 조건부 marketplace add 명령을 repo root 기준으로 보정 |
+| `mydocs/orders/20260516.md` | #38 비고를 Stage 1 완료 후 승인 대기 상태로 갱신 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 1은 신규 기술 노트와 단계 보고서를 추가했다. 기존 구현계획서는 공식 문서 재확인 결과에 맞춰 Stage 3 조건부 명령만 좁게 보정했다. `docs/`, `templates/`, plugin bundle 파일은 아직 변경하지 않았다.
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+codex --version
+codex plugin --help
+codex plugin marketplace --help
+codex plugin marketplace add --help
+rg -n '#38|thin wrapper|local marketplace|install/load|smoke|GO|NO-GO|hook 없는|hook 포함|public 배포' mydocs/tech/task_m040_37_codex_plugin_packaging_validation.md mydocs/report/task_m040_37_report.md
+rg -n 'OpenAI|Codex|plugin|hook|확인일|URL|local marketplace|install|load|smoke|재확인' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/working/task_m040_38_stage1.md
+git diff --check
+```
+
+결과:
+
+- OK: `codex --version`은 `codex-cli 0.131.0-alpha.9`를 출력했다. PATH update warning은 있었지만 version 확인은 성공했다.
+- OK: `codex plugin --help`에서 `marketplace` subcommand를 확인했다.
+- OK: `codex plugin marketplace --help`에서 `add`, `upgrade`, `remove`를 확인했다.
+- OK: `codex plugin marketplace add --help`에서 local marketplace root directory source 지원을 확인했다.
+- OK: #37 validation 문서와 최종 보고서에서 #38 thin wrapper, local marketplace, install/load smoke, hook 제외, public 배포 보류 조건을 확인했다.
+- OK: Stage 1 기술 노트와 보고서에서 OpenAI 공식 문서 확인, local marketplace, install/load smoke, 재확인 항목을 확인했다.
+- OK: `git diff --check`가 출력 없이 통과했다.
+
+수동 확인:
+
+- OK: 공식 문서 확인일과 URL을 Stage 1 기술 노트에 기록했다.
+- OK: #37의 hook 없는 thin wrapper GO 판단은 유지했다.
+- OK: 실행하지 않은 install/load를 완료처럼 쓰지 않고 Stage 3 조건부 smoke로 분리했다.
+- OK: repo marketplace의 `source.path`가 marketplace root 기준으로 해석된다는 공식 문서 기준에 맞춰 Stage 3 조건부 명령을 보정했다.
+
+## 잔여 위험
+
+- Stage 3의 실제 `codex plugin marketplace add .`는 local config/cache 변경 가능성이 있으므로 Stage 3 진입 시 별도 승인 항목으로 다시 확인해야 한다.
+- Thin wrapper Skill의 실제 discoverability는 Stage 2 bundle 생성과 Stage 3 smoke 전에는 확인되지 않았다.
+- Codex plugin/hooks 사양은 변동 가능성이 있으므로 public 배포 직전에는 한 번 더 확인해야 한다.
+
+## 다음 단계 영향
+
+- Stage 2는 `plugins/hyper-waterfall-codex/` 아래 hook 없는 thin wrapper bundle을 생성하면 된다.
+- Stage 2 manifest의 기본 구조는 `skills: "./skills/"`, `interface.capabilities: ["Read"]`, hooks/apps/MCP 제외로 둔다.
+- Stage 3 조건부 local marketplace add 명령은 repo root에서 `codex plugin marketplace add .` 후보로 다룬다.
+
+## 승인 요청
+
+- Stage 1 산출물과 검증 결과를 승인하면 Stage 2 - hook 없는 thin wrapper bundle 생성으로 진행한다.

--- a/mydocs/working/task_m040_38_stage2.md
+++ b/mydocs/working/task_m040_38_stage2.md
@@ -1,0 +1,68 @@
+# Task #38 Stage 2 보고서 - hook 없는 thin wrapper bundle 생성
+
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+구현계획서: [`task_m040_38_impl.md`](../plans/task_m040_38_impl.md)
+Stage: 2
+
+## 단계 목적
+
+Stage 2는 Stage 1에서 확정한 Codex plugin 사양과 #37 인계 조건을 실제 bundle 후보 파일로 만드는 단계다. 기본 scope는 hook 없는 thin wrapper이며, core Skill, manual, manifest, migration guide를 별도 진실 원천으로 복제하지 않는다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `plugins/hyper-waterfall-codex/.codex-plugin/plugin.json` | Codex plugin required manifest 생성. `skills: "./skills/"`, install-surface metadata, `Read` capability 설정 |
+| `plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md` | Hyper-Waterfall Codex thin wrapper Skill 생성. canonical 파일과 npm CLI dry-run으로 진입하도록 안내 |
+| `plugins/hyper-waterfall-codex/README.md` | local candidate 목적, 포함 파일, 설계 원칙, local smoke 후보, public 배포 승인 게이트 설명 |
+| `mydocs/tech/task_m040_38_codex_plugin_smoke.md` | Stage 2 bundle 생성 결과와 검증 결과 추가 |
+| `mydocs/working/task_m040_38_stage2.md` | Stage 2 단계 보고서 작성 |
+| `mydocs/orders/20260516.md` | #38 비고를 Stage 2 완료 후 승인 대기 상태로 갱신 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 2는 신규 plugin candidate 파일을 추가했다. 기존 canonical Skill, manual, manifest, migration guide 본문은 수정하거나 복제하지 않았다. 기존 구현계획서는 Stage 1에서 이미 보정됐고, 이번 Stage에서는 변경하지 않았다.
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+find plugins/hyper-waterfall-codex -maxdepth 5 -type f | sort
+jq . plugins/hyper-waterfall-codex/.codex-plugin/plugin.json
+rg -n 'AGENTS.md|mydocs/skills|docs/agent-entrypoint.md|npx hyper-waterfall|승인|canonical|진실 원천|not a canonical source|not execute public' plugins/hyper-waterfall-codex
+test ! -e plugins/hyper-waterfall-codex/templates/manifest.json
+test ! -d plugins/hyper-waterfall-codex/docs/migrations
+test ! -d plugins/hyper-waterfall-codex/templates/mydocs/manual
+git diff --check
+```
+
+결과:
+
+- OK: `find` 결과는 `.codex-plugin/plugin.json`, `README.md`, `skills/hyper-waterfall/SKILL.md` 세 파일이었다.
+- OK: `jq`가 `plugin.json`을 정상 JSON으로 파싱했다.
+- OK: wrapper와 README에서 `AGENTS.md`, `mydocs/skills`, `docs/agent-entrypoint.md`, `npx hyper-waterfall`, 승인 게이트, canonical source, 진실 원천, `not a canonical source`, `not execute public` 문구를 확인했다.
+- OK: `templates/manifest.json`, `docs/migrations`, `templates/mydocs/manual` 사본이 plugin bundle 안에 없음을 확인했다.
+- OK: `git diff --check`가 출력 없이 통과했다.
+
+수동 확인:
+
+- OK: `plugin.json`의 component path는 plugin root 내부 `./skills/`만 가리킨다.
+- OK: thin wrapper는 core Skill 본문을 fork하지 않고 canonical 파일과 npm CLI dry-run으로 넘긴다.
+- OK: 기본 bundle에 `hooks` field, `hooks/` directory, `[features].plugin_hooks = true` 요구 항목은 없다.
+
+## 잔여 위험
+
+- Thin wrapper가 실제 Codex plugin directory에서 충분히 발견되는지는 Stage 3 smoke 전에는 확인되지 않았다.
+- Plugin artifact version `0.2.0`은 framework version과 맞췄지만, public 배포 시 artifact version 의미를 release note나 install-surface copy에서 재확인해야 한다.
+- Visual asset은 아직 없다. Codex install surface에서 asset이 필요하면 Stage 4 후속 리스크로 남기거나 별도 작업으로 분리한다.
+
+## 다음 단계 영향
+
+- Stage 3은 `.agents/plugins/marketplace.json`을 만들고 repo root 기준 local marketplace smoke를 설계하면 된다.
+- Stage 3의 조건부 실행 후보는 `codex plugin marketplace add .`이며, local config/cache 변경 가능성 때문에 실행 전 승인 항목으로 다시 다뤄야 한다.
+- Stage 3에서 discoverability가 부족하면 release snapshot 후보를 Stage 4 보류/후속 항목으로 검토한다.
+
+## 승인 요청
+
+- Stage 2 산출물과 검증 결과를 승인하면 Stage 3 - local marketplace와 install/load/discovery smoke로 진행한다.

--- a/mydocs/working/task_m040_38_stage3.md
+++ b/mydocs/working/task_m040_38_stage3.md
@@ -1,0 +1,70 @@
+# Task #38 Stage 3 보고서 - local marketplace와 install/load/discovery smoke
+
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+구현계획서: [`task_m040_38_impl.md`](../plans/task_m040_38_impl.md)
+Stage: 3
+
+## 단계 목적
+
+Stage 3은 Stage 2에서 만든 Codex plugin 후보를 repo-local marketplace에 연결하고, Codex CLI에서 local marketplace add smoke가 가능한지 확인하는 단계다. 실제 public 배포는 이 단계 범위가 아니며, plugin UI discovery가 자동 검증되지 않으면 그 한계를 기록한다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `.agents/plugins/marketplace.json` | repo-local marketplace 후보 생성. `hyper-waterfall-local` marketplace가 `./plugins/hyper-waterfall-codex`를 가리킴 |
+| `mydocs/tech/task_m040_38_codex_plugin_smoke.md` | Stage 3 marketplace 구조, CLI add smoke, upgrade 한계, cleanup 결과 추가 |
+| `mydocs/working/task_m040_38_stage3.md` | Stage 3 단계 보고서 작성 |
+| `mydocs/orders/20260516.md` | #38 비고를 Stage 3 완료 후 승인 대기 상태로 갱신 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 3은 repo-local marketplace candidate를 새로 추가하고 smoke 결과를 문서화했다. Stage 2 plugin bundle 본문은 수정하지 않았다. 기존 manual, core Skill, manifest, migration guide 본문도 변경하지 않았다.
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+jq . .agents/plugins/marketplace.json
+rg -n 'hyper-waterfall|hyper-waterfall-codex|local|source|path|AVAILABLE|Productivity' .agents/plugins/marketplace.json
+codex plugin marketplace add --help
+codex plugin marketplace add .
+codex plugin marketplace upgrade hyper-waterfall-local
+codex plugin marketplace remove hyper-waterfall-local
+rg -n 'marketplace|install|load|discovery|cache|config|cleanup|restart|성공|실패|보류' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/working/task_m040_38_stage3.md
+git diff --check
+```
+
+결과:
+
+- OK: `jq`가 `.agents/plugins/marketplace.json`을 정상 JSON으로 파싱했다.
+- OK: `rg`로 marketplace name, plugin name, local source, path, `AVAILABLE`, `Productivity` metadata를 확인했다.
+- OK: `codex plugin marketplace add --help`에서 local marketplace root directory source 지원을 확인했다.
+- OK: `codex plugin marketplace add .`가 `hyper-waterfall-local` marketplace를 `/private/tmp/hyper-waterfall-task38`에서 추가했다고 출력했다.
+- OK with limit: `codex plugin marketplace upgrade hyper-waterfall-local`은 local marketplace가 Git marketplace가 아니므로 `not configured as a Git marketplace` 오류를 냈다. 이 오류는 local source 구조 실패가 아니라 upgrade 명령의 적용 범위 한계로 기록했다.
+- OK: `codex plugin marketplace remove hyper-waterfall-local`로 smoke 후 registration cleanup을 완료했다.
+- OK: Stage 3 기술 노트와 보고서에서 marketplace, install/load/discovery, cache/config cleanup, restart, 성공/실패/보류 관련 항목을 확인했다.
+- OK: `git diff --check`가 출력 없이 통과했다.
+
+수동 확인:
+
+- OK: `.agents/plugins/marketplace.json`의 `source.path`는 marketplace root 기준 `./plugins/hyper-waterfall-codex`다.
+- OK: CLI add smoke는 성공했지만 Codex restart 후 Plugin Directory 또는 CLI `/plugins` UI discovery는 자동화하지 않았다.
+- OK: cleanup이 필요한 local registration은 remove 명령으로 제거했다.
+
+## 잔여 위험
+
+- 실제 Codex app/CLI interactive Plugin Directory에서 plugin이 어떻게 표시되는지는 restart/UI 확인이 필요하다.
+- CLI add는 marketplace 등록 smoke이며, plugin Skill invocation까지 자동 확인하지는 못했다.
+- marketplace list 명령이 없어 remove 이후 등록 목록이 비었는지는 CLI output 외 추가 검증을 하지 못했다.
+
+## 다음 단계 영향
+
+- Stage 4는 public 배포 판단을 "repo-local marketplace add smoke 성공, UI discovery 수동 확인 필요"로 정리해야 한다.
+- Stage 4는 fallback 경로와 npm CLI help를 확인해, plugin discovery가 제한돼도 사용자 진입 경로가 유지되는지 판단해야 한다.
+- Thin wrapper discoverability가 부족하면 release snapshot bundle 후보를 후속 리스크로 남겨야 한다.
+
+## 승인 요청
+
+- Stage 3 산출물과 검증 결과를 승인하면 Stage 4 - fallback, 배포 판단, 최종 보고로 진행한다.

--- a/mydocs/working/task_m040_38_stage4.md
+++ b/mydocs/working/task_m040_38_stage4.md
@@ -1,0 +1,63 @@
+# Task #38 Stage 4 보고서 - fallback, 배포 판단, 최종 보고
+
+GitHub Issue: [#38](https://github.com/postmelee/hyper-waterfall/issues/38)
+구현계획서: [`task_m040_38_impl.md`](../plans/task_m040_38_impl.md)
+Stage: 4
+
+## 단계 목적
+
+Stage 4는 Stage 1-3 결과를 종합해 fallback 경로, npm CLI help, public 배포 go/no-go, 최종 수용 기준을 정리하는 단계다. 이 단계는 public 배포를 실행하지 않고, 별도 승인 전 보류 조건과 대체 경로를 명확히 남긴다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|---|---|
+| `mydocs/tech/task_m040_38_codex_plugin_smoke.md` | Stage 4 fallback, npm CLI help, public 배포 go/no-go, 결론 추가 |
+| `mydocs/working/task_m040_38_stage4.md` | Stage 4 단계 보고서 작성 |
+| `mydocs/report/task_m040_38_report.md` | Task #38 최종 보고서 작성 |
+| `mydocs/orders/20260516.md` | #38 비고를 Stage 4 및 최종 보고서 승인 대기 상태로 갱신 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 4는 기술 노트에 최종 판단을 추가하고 최종 보고서를 작성했다. Plugin bundle, marketplace 파일, 공통 배포 문서, core Skill, manual 본문은 수정하지 않았다.
+
+## 검증 결과
+
+실행 명령:
+
+```bash
+npx hyper-waterfall@0.2.0 --help
+rg -n 'public 배포|go/no-go|보류|fallback|AGENTS|agent-entrypoint|npm CLI|#38|install|load|discovery' mydocs/tech/task_m040_38_codex_plugin_smoke.md mydocs/report/task_m040_38_report.md
+rg -n 'Codex plugin|hyper-waterfall-codex|marketplace|plugin.json|thin wrapper' docs plugins .agents mydocs/report/task_m040_38_report.md
+git diff --check
+```
+
+결과:
+
+- WARN then OK: task worktree root에서 `npx hyper-waterfall@0.2.0 --help`는 `sh: hyper-waterfall: command not found`로 실패했다. 같은 package name source root에서 local package 우선 해석이 발생하는 기존 known issue와 일치한다.
+- OK: 빈 임시 디렉터리 `/private/tmp/hyper-waterfall-task38-npx.56eXYW`에서 `npx hyper-waterfall@0.2.0 --help`를 재실행했고 `init`, `update`, `doctor`, canonical 기준 안내가 출력됐다.
+- OK: 기술 노트와 최종 보고서에서 public 배포, go/no-go, 보류, fallback, AGENTS, agent-entrypoint, npm CLI, #38, install/load/discovery 항목을 확인했다.
+- OK: docs, plugin bundle, marketplace, 최종 보고서에서 Codex plugin, `hyper-waterfall-codex`, marketplace, `plugin.json`, thin wrapper 항목을 확인했다.
+- OK: `git diff --check`가 출력 없이 통과했다.
+
+수동 확인:
+
+- OK: 최종 보고서는 issue #38 수용 기준을 모두 대응한다.
+- OK: public 배포는 실행하지 않았고, 별도 승인 전 보류로 기록했다.
+- OK: 보류 사유는 UI discovery/Skill invocation 수동 확인 필요와 별도 승인 부재로 정리했다.
+
+## 잔여 위험
+
+- Codex app/CLI interactive Plugin Directory에서 실제 표시와 Skill invocation은 restart/UI 확인이 필요하다.
+- Public 배포용 install-surface asset, screenshot, legal link가 필요하면 별도 보강이 필요하다.
+- Thin wrapper discoverability가 부족하면 release snapshot bundle 후보를 후속으로 검토해야 한다.
+
+## 다음 단계 영향
+
+- PR 게시 승인이 나면 `task-final-report` 절차로 오늘할일 완료 처리, publish 브랜치 push, PR 생성을 진행한다.
+- Public 배포 실행은 PR 리뷰와 별도 작업지시자 승인 후 진행해야 한다.
+- Hook guardrail은 #38 기본 bundle에서 제외됐으므로 필요 시 별도 이슈로 분리한다.
+
+## 승인 요청
+
+- Stage 4 산출물과 최종 보고서 검증 결과를 승인하면 최종 PR 게시 절차로 진행한다.

--- a/plugins/hyper-waterfall-codex/.codex-plugin/plugin.json
+++ b/plugins/hyper-waterfall-codex/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "hyper-waterfall",
+  "version": "0.2.0",
+  "description": "Discover Hyper-Waterfall workflows and lifecycle checks in Codex.",
+  "repository": "https://github.com/postmelee/hyper-waterfall",
+  "license": "MIT",
+  "keywords": [
+    "workflow",
+    "codex",
+    "project-management"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Hyper-Waterfall",
+    "shortDescription": "Issue-first waterfall workflow guardrails for coding agents.",
+    "longDescription": "Use Hyper-Waterfall workflow entrypoints, lifecycle checks, and fallback guidance from Codex without making the plugin a new canonical source.",
+    "developerName": "postmelee",
+    "category": "Productivity",
+    "capabilities": [
+      "Read"
+    ],
+    "websiteURL": "https://github.com/postmelee/hyper-waterfall",
+    "defaultPrompt": [
+      "Use Hyper-Waterfall to start the current GitHub issue workflow.",
+      "Use Hyper-Waterfall to check whether this repository should be initialized or updated."
+    ]
+  }
+}

--- a/plugins/hyper-waterfall-codex/README.md
+++ b/plugins/hyper-waterfall-codex/README.md
@@ -1,0 +1,46 @@
+# Hyper-Waterfall Codex Plugin Candidate
+
+이 디렉터리는 Task #38에서 만든 Codex plugin 배포 후보이다. 목적은 Codex 사용자가 Hyper-Waterfall의 issue-first workflow, core Skill, lifecycle entrypoint를 쉽게 발견하게 하는 것이다.
+
+This plugin is not a canonical source. Hyper-Waterfall의 canonical source는 GitHub Release/tag, `templates/manifest.json`, `docs/migrations/`, `docs/agent-entrypoint.md`, `templates/mydocs/skills/`, `templates/mydocs/manual/`, npm CLI다.
+
+## 포함 파일
+
+```text
+plugins/hyper-waterfall-codex/
+  .codex-plugin/
+    plugin.json
+  skills/
+    hyper-waterfall/
+      SKILL.md
+  README.md
+```
+
+## 설계 원칙
+
+- `.codex-plugin/plugin.json`은 `skills: "./skills/"`만 사용한다.
+- `skills/hyper-waterfall/SKILL.md`는 thin wrapper이며 core Skill 본문을 복제하지 않는다.
+- `templates/manifest.json`, migration guide, manual 전문은 plugin bundle에 포함하지 않는다.
+- hooks, apps, MCP servers는 기본 bundle에 포함하지 않는다.
+- public distribution은 smoke 결과와 작업지시자 별도 승인 전에는 실행하지 않는다.
+
+## 사용 흐름
+
+1. 현재 저장소의 `AGENTS.md`를 읽는다.
+2. task 절차는 현재 저장소의 `mydocs/skills/{skill-name}/SKILL.md`를 읽고 따른다.
+3. 신규 적용 또는 기존 업데이트 판단은 `docs/agent-entrypoint.md`와 npm CLI dry-run을 사용한다.
+4. 필요한 canonical 파일이 없으면 파일을 만들지 말고 사용자에게 경로와 release 기준을 확인한다.
+
+## Local smoke 후보
+
+repo marketplace는 repository root의 `.agents/plugins/marketplace.json`에 둔다. Codex 공식 문서 기준으로 `source.path`는 marketplace root 기준으로 해석되므로 local marketplace add 후보는 repository root에서 다음 형태다.
+
+```bash
+codex plugin marketplace add .
+```
+
+이 명령은 local config/cache를 변경할 수 있으므로 Task #38 Stage 3에서 별도 승인 후 실행한다.
+
+## 공개 배포 게이트
+
+Do not execute public distribution from this plugin candidate without explicit maintainer approval. Local smoke 통과는 public 배포 승인이 아니다.

--- a/plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md
+++ b/plugins/hyper-waterfall-codex/skills/hyper-waterfall/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: hyper-waterfall
+description: Hyper-Waterfall workflow entrypoint for Codex. Use when starting or continuing issue-based Hyper-Waterfall tasks, checking lifecycle init/update paths, or finding canonical manuals and skills.
+---
+
+# Hyper-Waterfall Codex Entrypoint
+
+This plugin is not a canonical source.
+
+## 우선순위
+
+1. 현재 저장소의 `AGENTS.md`를 먼저 읽는다.
+2. 정형 task 절차는 현재 저장소의 `mydocs/skills/{skill-name}/SKILL.md`를 읽고 따른다.
+3. 신규 적용 또는 기존 업데이트 판단은 `docs/agent-entrypoint.md`, `templates/manifest.json`, `docs/migrations/`, npm CLI dry-run을 기준으로 한다.
+4. canonical 파일을 찾지 못하면 파일을 만들지 말고 사용자에게 저장소 루트, target release, Hyper-Waterfall 설치 여부 확인을 요청한다.
+
+## 허용 동작
+
+- 사용자가 GitHub Issue 기반 작업을 시작하거나 이어가려면 해당 저장소의 `AGENTS.md`와 관련 core Skill을 읽도록 안내한다.
+- 신규 적용 판단은 `docs/agent-entrypoint.md`의 판단 결과 형식과 `npx hyper-waterfall@0.2.0 init --repo . --dry-run`을 우선한다.
+- 기존 업데이트 판단은 `.hyper-waterfall/version.json`, 목표 release의 `templates/manifest.json`, migration guide, `npx hyper-waterfall@0.2.0 update --repo . --dry-run`을 우선한다.
+- 상태 점검은 `npx hyper-waterfall@0.2.0 doctor --repo .` 또는 `npx hyper-waterfall@0.2.0 --help`로 안내한다.
+
+## 금지 동작
+
+- core Skill 본문을 이 plugin 안에서 재작성하지 않는다.
+- `templates/manifest.json`, migration guide, manual 본문을 이 plugin의 새 진실 원천으로 취급하지 않는다.
+- 작업지시자 승인 없이 파일을 수정하거나 task stage를 건너뛰지 않는다.
+- 작업지시자 승인 없이 issue close, PR merge, publish, release 생성 같은 외부 공개 action을 수행하지 않는다.
+- Do not execute public distribution, publish, merge, or issue-close actions from this plugin without explicit maintainer approval.
+
+## Fallback
+
+plugin 환경에서 필요한 canonical 파일을 읽을 수 없으면 절차를 임의로 재구성하지 않는다. 사용자에게 현재 저장소 루트와 Hyper-Waterfall release 기준을 확인하고, 가능하면 npm CLI dry-run으로 판단 결과만 출력하도록 요청한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #38 Codex plugin 배포 후보 생성과 설치 smoke
- 왜: #37에서 검증한 Codex plugin packaging 결과를 실제 repo-local 후보와 smoke 기록으로 고정하기 위해
- 무엇: hook 없는 thin wrapper Codex plugin, repo-local marketplace, local marketplace add smoke, fallback/public 배포 판단 문서화
- 리뷰 포인트: public 배포는 #52 후속 이슈로 분리하고, 이번 PR은 local candidate와 smoke 근거를 고정하는 범위

## 변경 내역

- **계획 수립** ([7684e25](https://github.com/postmelee/hyper-waterfall/commit/7684e25)): 수행계획서 작성과 오늘할일 등록
- **구현계획 수립** ([b1bc946](https://github.com/postmelee/hyper-waterfall/commit/b1bc946)): Stage 1-4 산출물, 검증, public 배포 게이트 정의
- **[Stage 1](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/working/task_m040_38_stage1.md)** ([0807f91](https://github.com/postmelee/hyper-waterfall/commit/0807f91)): Codex 공식 사양과 local CLI surface 재확인
- **[Stage 2](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/working/task_m040_38_stage2.md)** ([57050b2](https://github.com/postmelee/hyper-waterfall/commit/57050b2)): hook 없는 thin wrapper bundle 생성
- **[Stage 3](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/working/task_m040_38_stage3.md)** ([7f604e2](https://github.com/postmelee/hyper-waterfall/commit/7f604e2)): repo-local marketplace와 `codex plugin marketplace add .` smoke 검증
- **[Stage 4](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/working/task_m040_38_stage4.md)** ([6e57dcf](https://github.com/postmelee/hyper-waterfall/commit/6e57dcf)): fallback, npm CLI help, public 배포 go/no-go, 최종 보고서 정리
- **완료 처리** ([1f24fa8](https://github.com/postmelee/hyper-waterfall/commit/1f24fa8)): 오늘할일 완료 처리와 후속 이슈 #52 반영

### 영향 영역

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Codex plugin 후보 | `plugins/hyper-waterfall-codex/` manifest, thin wrapper Skill, README 추가 | canonical source를 복제하지 않는 얇은 wrapper인지 |
| Codex local marketplace | `.agents/plugins/marketplace.json` 추가 | `source.path`가 repo marketplace root 기준으로 맞는지 |
| Task 문서 | Stage 보고서, smoke 기술 노트, 최종 보고서 추가 | public 배포 보류와 #52 후속 분리가 명확한지 |

### 작업 문서

- 수행 계획서: [task_m040_38.md](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/plans/task_m040_38.md)
- 구현 계획서: [task_m040_38_impl.md](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/plans/task_m040_38_impl.md)
- smoke 기술 노트: [task_m040_38_codex_plugin_smoke.md](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/tech/task_m040_38_codex_plugin_smoke.md)
- 최종 보고서: [task_m040_38_report.md](https://github.com/postmelee/hyper-waterfall/blob/1f24fa8c835be8c6def057e7fe95138757a547f5/mydocs/report/task_m040_38_report.md)

## 핵심 리뷰 포인트

- plugin 후보가 `templates/manifest.json`, migration guide, manual, core Skill 본문을 새 진실 원천으로 복제하지 않는지
- `.agents/plugins/marketplace.json`의 `source.path`가 repo root marketplace 기준 `./plugins/hyper-waterfall-codex`로 맞는지
- public 배포를 이번 PR에서 실행하지 않고 #52로 분리한 판단이 타당한지

## 검증

### 자동 검증

| 주제 | 검증 방법 | 결과 | 근거 |
|------|-----------|------|------|
| Codex CLI/plugin surface | `codex --version`, `codex plugin --help`, `codex plugin marketplace --help`, `codex plugin marketplace add --help` | OK | `codex-cli 0.131.0-alpha.9`, `marketplace add/upgrade/remove`, local marketplace root source 지원 확인 |
| Plugin manifest와 wrapper | `find plugins/hyper-waterfall-codex -maxdepth 5 -type f`, `jq . plugins/hyper-waterfall-codex/.codex-plugin/plugin.json`, `rg ... plugins/hyper-waterfall-codex` | OK | manifest/README/SKILL 세 파일, 정상 JSON, canonical/fallback/승인 게이트 문구 확인 |
| 금지 복제 부재 | `test ! -e plugins/hyper-waterfall-codex/templates/manifest.json`, `test ! -d plugins/hyper-waterfall-codex/docs/migrations`, `test ! -d plugins/hyper-waterfall-codex/templates/mydocs/manual` | OK | manifest, migration guide, manual 전문 사본 없음 |
| Repo-local marketplace | `jq . .agents/plugins/marketplace.json`, `rg -n 'hyper-waterfall|hyper-waterfall-codex|local|source|path|AVAILABLE|Productivity' .agents/plugins/marketplace.json` | OK | marketplace name, local source, path, policy, category 확인 |
| npm CLI fallback | 빈 임시 디렉터리에서 `npx hyper-waterfall@0.2.0 --help` | OK | `init`, `update`, `doctor`, canonical 기준 안내 출력 |
| 최종 문서 grep | `rg -n 'public 배포|go/no-go|보류|fallback|AGENTS|agent-entrypoint|npm CLI|#38|install|load|discovery' ...` 및 `rg -n 'Codex plugin|hyper-waterfall-codex|marketplace|plugin.json|thin wrapper' ...` | OK | public 배포 보류, fallback, install/load/discovery, plugin 후보 항목 확인 |
| diff 정합성 | `git diff --check`, `git diff --check HEAD~1..HEAD` | OK | 공백 오류 출력 없음 |

### 수동/시나리오 검증

| 시나리오 | 확인 절차 | 결과 | 자료 |
|----------|-----------|------|------|
| Local marketplace add smoke | `codex plugin marketplace add .` 실행 후 `codex plugin marketplace remove hyper-waterfall-local`로 cleanup | OK | Codex가 `/private/tmp/hyper-waterfall-task38`을 marketplace root로 인식했고 remove 성공 |
| Public 배포 판단 | Stage 4와 최종 보고서에서 go/no-go 검토 | OK | Public 배포는 별도 승인과 UI discovery 확인이 필요해 #52로 분리 |

### CI/원격 검증

PR 생성 전에는 GitHub Check가 아직 생성되지 않아 원격 검증을 실행하지 않았다.

### 검증 한계

- Codex Plugin Directory UI 표시와 Skill invocation은 Codex restart/UI 확인이 필요해 자동 검증하지 않았다.
- task source root에서 `npx hyper-waterfall@0.2.0 --help`는 local package 우선 해석으로 실패할 수 있어, 사용자 경로에 가까운 빈 임시 디렉터리에서 재검증했다.
- Public 배포는 이번 PR에서 실행하지 않았고 #52에서 별도 승인 게이트로 다룬다.

## 관련 이슈

- [#37 Codex plugin packaging 검증](https://github.com/postmelee/hyper-waterfall/issues/37)
- [#52 Codex plugin public 배포와 UI discovery smoke](https://github.com/postmelee/hyper-waterfall/issues/52)

## 후속 이슈 제안

- 없음. public 배포와 UI discovery smoke는 [#52](https://github.com/postmelee/hyper-waterfall/issues/52)로 등록 완료.

## 남은 리스크

- Codex Plugin Directory UI discovery와 Skill invocation은 #52에서 수동 smoke가 필요하다.
- Public 배포용 visual asset, screenshot, privacy/terms URL 같은 install-surface 보강이 필요할 수 있다.
